### PR TITLE
Add ament_cmake_clang_tidy package

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -46,6 +46,7 @@ skip_existing:
 packages_select_by_deps:
   - ament_cmake_core
   - ament_cmake_catch2
+  - ament_cmake_clang_tidy
   - ament_cmake_mypy
   - rosidl_buffer
   - rosidl_buffer_backend


### PR DESCRIPTION
Adds `ament_cmake_clang_tidy` to `packages_select_by_deps` in `vinca.yaml`, alongside the other `ament_cmake_*` seeds.

The package is available in the lyrical rosdistro snapshot (`release/lyrical/ament_cmake_clang_tidy/0.20.6-1`), so dependency resolution will pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)