### PR TITLE
Fix pixi crash on liblttng-ust-dev

### DIFF
--- a/robostack.yaml
+++ b/robostack.yaml
@@ -354,7 +354,10 @@ libhdf5-dev:
 libi2c-dev:
   robostack: [libi2c]
 liblttng-ust-dev:
-  robostack: ["${{ \"lttng-ust\" if linux }}"]
+  robostack:
+    linux: [lttng-ust]
+    osx: []
+    win64: []
 libjpeg:
   robostack: [libjpeg-turbo]
 libjsoncpp:


### PR DESCRIPTION
Same as: https://github.com/RoboStack/ros-jazzy/pull/230