### PR TITLE
Add MoveIt Task Constructor packages (core, capabilities, visualization, demo, rviz_marker_tools)

### DIFF
--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -4,6 +4,7 @@ on:
 
 env:
   ROS_VERSION: 2
+  PYTHONIOENCODING: utf-8
   # Change to 'true' to enable the cache upload as artifacts
   SAVE_CACHE_AS_ARTIFACT: 'true'
   # Change to 'true' to ignore cache and force a full rebuild, but please restore to 'false' before merging

--- a/patch/ros-lyrical-moveit-task-constructor-capabilities.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-capabilities.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,7 +20,7 @@ add_library(${PROJECT_NAME} SHARED
+    src/execute_task_solution_capability.cpp
+ )
+ target_link_libraries(${PROJECT_NAME} PUBLIC
+-  fmt
++  fmt::fmt
+   ${rclcpp_action_TARGETS}
+   ${moveit_core_TARGETS}
+   ${moveit_ros_move_group_TARGETS}

--- a/patch/ros-lyrical-moveit-task-constructor-core.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-core.patch
@@ -92,6 +92,17 @@ diff --git a/src/introspection.cpp b/src/introspection.cpp
 index d938f95..85292d9 100644
 --- a/src/introspection.cpp
 +++ b/src/introspection.cpp
+@@ -49,6 +49,10 @@
+ #include <sstream>
+ #include <boost/bimap.hpp>
+ 
++#ifdef _WIN32
++#include <winsock.h>
++#endif
++
+ namespace ros {
+ namespace names {
+ bool isValidCharInName(char c);  // unfortunately this is not declared in ros/names.h
 @@ -214,7 +214,7 @@ void Introspection::publishAllSolutions(bool wait) {
  	};
  }

--- a/patch/ros-lyrical-moveit-task-constructor-core.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-core.patch
@@ -115,7 +115,7 @@ index d938f95..35d502a 100644
 +	#ifdef _WIN32
 +	{
 +		static bool wsa_initialised = false;
-+		if (wsa_initialised) {
++		if (!wsa_initialised) {
 +			WSADATA wsaData;
 +			WSAStartup(MAKEWORD(2, 2), &wsaData);
 +			wsa_initialised = true;

--- a/patch/ros-lyrical-moveit-task-constructor-core.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-core.patch
@@ -1,0 +1,78 @@
+diff --git a/python/bindings/CMakeLists.txt b/python/bindings/CMakeLists.txt
+index 26c86ac..d5cd670 100644
+--- a/python/bindings/CMakeLists.txt
++++ b/python/bindings/CMakeLists.txt
+@@ -17,6 +17,7 @@ pybind11_add_module(pymoveit_mtc
+ )
+ target_include_directories(pymoveit_mtc PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
+ target_link_libraries(pymoveit_mtc PUBLIC ${PROJECT_NAME} ${PROJECT_NAME}_stages ${PROJECT_NAME}_python_tools)
++set_target_properties(pymoveit_mtc PROPERTIES CXX_SCAN_FOR_MODULES OFF)
+ 
+ # install libs
+ install(TARGETS ${PROJECT_NAME}_python_tools
+diff --git a/src/cost_terms.cpp b/src/cost_terms.cpp
+index 9ddb94f..9896d36 100644
+--- a/src/cost_terms.cpp
++++ b/src/cost_terms.cpp
+@@ -298,8 +298,8 @@ double Clearance::operator()(const SubTrajectory& s, std::string& comment) const
+ 	} };
+ 
+ 	auto collision_comment = [=](const auto& distance) {
+-		return fmt::format(PREFIX + "allegedly valid solution collides between '{}' and '{}'", distance.link_names[0],
+-		                   distance.link_names[1]);
++		return fmt::format(fmt::runtime(PREFIX + "allegedly valid solution collides between '{}' and '{}'"),
++		                   distance.link_names[0], distance.link_names[1]);
+ 	};
+ 
+ 	double distance{ 0.0 };
+@@ -313,10 +313,10 @@ double Clearance::operator()(const SubTrajectory& s, std::string& comment) const
+ 		}
+ 		distance = distance_data.distance;
+ 		if (!cumulative)
+-			comment = fmt::format(PREFIX + "distance {} between '{}' and '{}'", distance, distance_data.link_names[0],
+-			                      distance_data.link_names[1]);
++			comment = fmt::format(fmt::runtime(PREFIX + "distance {} between '{}' and '{}'"), distance,
++			                      distance_data.link_names[0], distance_data.link_names[1]);
+ 		else
+-			comment = fmt::format(PREFIX + "cumulative distance {}", distance);
++			comment = fmt::format(fmt::runtime(PREFIX + "cumulative distance {}"), distance);
+ 	} else {  // check trajectory
+ 		for (size_t i = 0; i < s.trajectory()->getWayPointCount(); ++i) {
+ 			auto distance_data = check_distance(state, s.trajectory()->getWayPoint(i));
+@@ -327,7 +327,7 @@ double Clearance::operator()(const SubTrajectory& s, std::string& comment) const
+ 			distance += distance_data.distance;
+ 		}
+ 		distance /= s.trajectory()->getWayPointCount();
+-		comment = fmt::format(PREFIX + "average{} distance: {}", (cumulative ? " cumulative" : ""), distance);
++		comment = fmt::format(fmt::runtime(PREFIX + "average{} distance: {}"), (cumulative ? " cumulative" : ""), distance);
+ 	}
+ 
+ 	return distance_to_cost(distance);
+diff --git a/src/properties.cpp b/src/properties.cpp
+index 8c001de..6fd0217 100644
+--- a/src/properties.cpp
++++ b/src/properties.cpp
+@@ -38,6 +38,7 @@
+ 
+ #include <moveit/task_constructor/properties.h>
+ #include <moveit/task_constructor/fmt_p.h>
++#include <boost/core/demangle.hpp>
+ #include <functional>
+ #include <rclcpp/logging.hpp>
+ #include <rclcpp/clock.hpp>
+diff --git a/src/stage.cpp b/src/stage.cpp
+index b64ce0a..a9eb8a0 100644
+--- a/src/stage.cpp
++++ b/src/stage.cpp
+@@ -909,8 +909,9 @@ bool Connecting::compatible(const InterfaceState& from_state, const InterfaceSta
+ 	const planning_scene::PlanningSceneConstPtr& from = from_state.scene();
+ 	const planning_scene::PlanningSceneConstPtr& to = to_state.scene();
+ 
+-	auto false_with_debug = [](auto... args) {
+-		RCLCPP_DEBUG_STREAM(rclcpp::get_logger("Connecting"), fmt::format(args...));
++	auto false_with_debug = [](fmt::string_view format_str, auto&&... args) {
++		RCLCPP_DEBUG_STREAM(rclcpp::get_logger("Connecting"),
++		                    fmt::vformat(format_str, fmt::make_format_args(args...)));
+ 		return false;
+ 	};
+ 

--- a/patch/ros-lyrical-moveit-task-constructor-core.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-core.patch
@@ -24,18 +24,19 @@ index e217ad6..708a2fb 100644
  	/// function callback used to initialize property value from another PropertyMap
  	using InitializerFunction = std::function<boost::any(const PropertyMap&)>;
  
-diff --git a/python/bindings/CMakeLists.txt b/python/bindings/CMakeLists.txt
-index 26c86ac..d5cd670 100644
---- a/python/bindings/CMakeLists.txt
-+++ b/python/bindings/CMakeLists.txt
-@@ -17,6 +17,7 @@ pybind11_add_module(pymoveit_mtc
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 82e9875..147aa7b 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -38,7 +38,7 @@ add_library(${PROJECT_NAME} SHARED
+ 	solvers/multi_planner.cpp
  )
- target_include_directories(pymoveit_mtc PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
- target_link_libraries(pymoveit_mtc PUBLIC ${PROJECT_NAME} ${PROJECT_NAME}_stages ${PROJECT_NAME}_python_tools)
-+set_target_properties(pymoveit_mtc PROPERTIES CXX_SCAN_FOR_MODULES OFF)
- 
- # install libs
- install(TARGETS ${PROJECT_NAME}_python_tools
+ target_link_libraries(${PROJECT_NAME}
+-	fmt
++	fmt::fmt
+ 	${moveit_core_TARGETS}
+ 	${moveit_ros_planning_TARGETS}
+ 	${moveit_ros_planning_interface_TARGETS}
 diff --git a/src/container.cpp b/src/container.cpp
 index febc00f..fded044 100644
 --- a/src/container.cpp
@@ -235,3 +236,56 @@ index 1c0553c..39bfa92 100644
  	auto cb = [&called](const SolutionBase& /* s */) {
  		++called;
  		return true;
+diff --git a/python/bindings/CMakeLists.txt b/python/bindings/CMakeLists.txt
+--- a/python/bindings/CMakeLists.txt
++++ b/python/bindings/CMakeLists.txt
+@@ -2,8 +2,15 @@
+ add_library(${PROJECT_NAME}_python_tools SHARED
+ 	${INCLUDES}/properties.h
+ 	src/properties.cpp
+ )
++# Force our vendored (smart_holder) pybind11 to be found before any pybind11
++# pulled in transitively via py_binding_tools, which links against the plain
++# upstream pybind11 package. Mixing the two copies in one translation unit
++# causes duplicate-definition errors, since smart_holder.h only exists in
++# the vendored fork.
++target_include_directories(${PROJECT_NAME}_python_tools BEFORE PUBLIC
++	${CMAKE_CURRENT_SOURCE_DIR}/../pybind11/include)
+ target_link_libraries(${PROJECT_NAME}_python_tools PUBLIC ${PROJECT_NAME}
+ 	pybind11::pybind11 py_binding_tools::py_binding_tools)
+ # Use minimum-size optimization for pybind11 bindings
+ target_link_libraries(${PROJECT_NAME}_python_tools PUBLIC pybind11::opt_size)
+@@ -15,7 +15,9 @@
+ 	src/stages.cpp
+ 	src/module.cpp
+ )
++target_include_directories(pymoveit_mtc BEFORE PUBLIC
++	${CMAKE_CURRENT_SOURCE_DIR}/../pybind11/include)
+ target_include_directories(pymoveit_mtc PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
+ target_link_libraries(pymoveit_mtc PUBLIC ${PROJECT_NAME} ${PROJECT_NAME}_stages ${PROJECT_NAME}_python_tools)
+ 
+ # install libs
+diff --git a/python/bindings/src/properties.cpp b/python/bindings/src/properties.cpp
+--- a/python/bindings/src/properties.cpp
++++ b/python/bindings/src/properties.cpp
+@@ -158,6 +158,8 @@
+ 	return REGISTRY_SINGLETON.insert(type_index, ros_msg_name, to, from);
+ }
+ 
++#if !defined(_MSC_VER)
+ __attribute__((visibility("default"))) // export this symbol as visible in the shared library
++#endif
+ void export_properties(py::module& m) {
+ 	// clang-format off
+diff --git a/python/bindings/src/solvers.cpp b/python/bindings/src/solvers.cpp
+--- a/python/bindings/src/solvers.cpp
++++ b/python/bindings/src/solvers.cpp
+@@ -73,7 +73,7 @@
+ 				pipelinePlanner = core.PipelinePlanner(node, 'ompl', 'PRMkConfigDefault')
+ 				pipelinePlanner.num_planning_attempts = 10
+ 			)")
+-	    .property<uint>("num_planning_attempts", "int: Number of planning attempts")
++	    .property<uint32_t>("num_planning_attempts", "int: Number of planning attempts")
+ 	    .property<moveit_msgs::msg::WorkspaceParameters>(
+ 	        "workspace_parameters",
+ 	        ":moveit_msgs:`WorkspaceParameters`: Specifies workspace box to be used for Cartesian sampling")

--- a/patch/ros-lyrical-moveit-task-constructor-core.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-core.patch
@@ -255,7 +255,7 @@ diff --git a/python/bindings/CMakeLists.txt b/python/bindings/CMakeLists.txt
  	pybind11::pybind11 py_binding_tools::py_binding_tools)
  # Use minimum-size optimization for pybind11 bindings
  target_link_libraries(${PROJECT_NAME}_python_tools PUBLIC pybind11::opt_size)
-@@ -15,7 +15,9 @@
+@@ -15,7 +15,13 @@
  	src/stages.cpp
  	src/module.cpp
  )
@@ -263,7 +263,11 @@ diff --git a/python/bindings/CMakeLists.txt b/python/bindings/CMakeLists.txt
 +	${CMAKE_CURRENT_SOURCE_DIR}/../pybind11/include)
  target_include_directories(pymoveit_mtc PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
  target_link_libraries(pymoveit_mtc PUBLIC ${PROJECT_NAME} ${PROJECT_NAME}_stages ${PROJECT_NAME}_python_tools)
- 
++# CMake's C++20 module dependency scanner misparses pybind11::module-typed
++# locals in headers pulled in transitively (py_binding_tools) as module
++# control-lines; this target doesn't use C++20 modules, so just disable it.
++set_target_properties(pymoveit_mtc PROPERTIES CXX_SCAN_FOR_MODULES OFF)
+
  # install libs
 diff --git a/python/bindings/src/properties.cpp b/python/bindings/src/properties.cpp
 --- a/python/bindings/src/properties.cpp

--- a/patch/ros-lyrical-moveit-task-constructor-core.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-core.patch
@@ -237,38 +237,20 @@ index 1c0553c..39bfa92 100644
  		++called;
  		return true;
 diff --git a/python/bindings/CMakeLists.txt b/python/bindings/CMakeLists.txt
+index 26c86ac..22bf5e1 100644
 --- a/python/bindings/CMakeLists.txt
 +++ b/python/bindings/CMakeLists.txt
-@@ -2,8 +2,15 @@
- add_library(${PROJECT_NAME}_python_tools SHARED
- 	${INCLUDES}/properties.h
- 	src/properties.cpp
+@@ -17,6 +17,10 @@ pybind11_add_module(pymoveit_mtc
  )
-+# Force our vendored (smart_holder) pybind11 to be found before any pybind11
-+# pulled in transitively via py_binding_tools, which links against the plain
-+# upstream pybind11 package. Mixing the two copies in one translation unit
-+# causes duplicate-definition errors, since smart_holder.h only exists in
-+# the vendored fork.
-+target_include_directories(${PROJECT_NAME}_python_tools BEFORE PUBLIC
-+	${CMAKE_CURRENT_SOURCE_DIR}/../pybind11/include)
- target_link_libraries(${PROJECT_NAME}_python_tools PUBLIC ${PROJECT_NAME}
- 	pybind11::pybind11 py_binding_tools::py_binding_tools)
- # Use minimum-size optimization for pybind11 bindings
- target_link_libraries(${PROJECT_NAME}_python_tools PUBLIC pybind11::opt_size)
-@@ -15,7 +15,13 @@
- 	src/stages.cpp
- 	src/module.cpp
- )
-+target_include_directories(pymoveit_mtc BEFORE PUBLIC
-+	${CMAKE_CURRENT_SOURCE_DIR}/../pybind11/include)
  target_include_directories(pymoveit_mtc PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
  target_link_libraries(pymoveit_mtc PUBLIC ${PROJECT_NAME} ${PROJECT_NAME}_stages ${PROJECT_NAME}_python_tools)
 +# CMake's C++20 module dependency scanner misparses pybind11::module-typed
 +# locals in headers pulled in transitively (py_binding_tools) as module
 +# control-lines; this target doesn't use C++20 modules, so just disable it.
 +set_target_properties(pymoveit_mtc PROPERTIES CXX_SCAN_FOR_MODULES OFF)
-
+ 
  # install libs
+ install(TARGETS ${PROJECT_NAME}_python_tools
 diff --git a/python/bindings/src/properties.cpp b/python/bindings/src/properties.cpp
 --- a/python/bindings/src/properties.cpp
 +++ b/python/bindings/src/properties.cpp
@@ -293,3 +275,195 @@ diff --git a/python/bindings/src/solvers.cpp b/python/bindings/src/solvers.cpp
  	    .property<moveit_msgs::msg::WorkspaceParameters>(
  	        "workspace_parameters",
  	        ":moveit_msgs:`WorkspaceParameters`: Specifies workspace box to be used for Cartesian sampling")
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 181e1a4..fcb7315 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -1,28 +1,12 @@
+-# We rely on pybind11's smart_holder branch imported pybind11 via git submodule
+-
++# Use the pybind11 provided by the environment (with upstream smart_holder support since 3.0),
++# rather than vendoring our own fork, so we share a single pybind11 with py_binding_tools.
+ find_package(ament_cmake_python REQUIRED)
+ find_package(Python3 COMPONENTS Interpreter Development)
+-# pybind11 must use the ROS python version
+-set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION})
++find_package(pybind11 REQUIRED)
+ 
+ # Use minimum-size optimization for pybind11 bindings
+ add_compile_options("-Os")
+ 
+-# configure pybind11 install for use by downstream packages in install space
+-set(PYBIND11_INSTALL ON CACHE INTERNAL "Install pybind11")
+-set(CMAKE_INSTALL_INCLUDEDIR include/moveit/python)
+-set(PYBIND11_CMAKECONFIG_INSTALL_DIR share/${PROJECT_NAME}/cmake
+-    CACHE INTERNAL "install path for pybind11 cmake files")
+-
+-# source pybind11 folder, which exposes its targets and installs them
+-if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/pybind11/CMakeLists.txt")
+-	message("Missing content of submodule pybind11: Use 'git clone --recurse-submodule' in future.\n"
+-	        "Checking out content automatically")
+-	execute_process(COMMAND git submodule init WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+-	execute_process(COMMAND git submodule update WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+-endif()
+-add_subdirectory(pybind11)
+-
+ # C++ wrapper code
+ add_subdirectory(bindings)
+ 
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1b8d21a..1d9f5d7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,6 +12,8 @@ find_package(moveit_core REQUIRED)
+ find_package(moveit_ros_planning REQUIRED)
+ find_package(moveit_ros_planning_interface REQUIRED)
+ find_package(moveit_task_constructor_msgs REQUIRED)
++find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
++find_package(pybind11 REQUIRED)
+ find_package(py_binding_tools REQUIRED)
+ find_package(rclcpp REQUIRED)
+ find_package(rviz_marker_tools REQUIRED)
+diff --git a/include/moveit/python/task_constructor/properties.h b/include/moveit/python/task_constructor/properties.h
+index 46c0e97..70bf30e 100644
+--- a/include/moveit/python/task_constructor/properties.h
++++ b/include/moveit/python/task_constructor/properties.h
+@@ -1,14 +1,10 @@
+ #pragma once
+ 
+-#include <pybind11/smart_holder.h>
+ #include <py_binding_tools/ros_msg_typecasters.h>
+ #include <moveit/task_constructor/properties.h>
+ #include <boost/any.hpp>
+ #include <typeindex>
+ 
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::Property)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::PropertyMap)
+-
+ namespace moveit {
+ namespace python {
+ 
+diff --git a/python/bindings/src/core.h b/python/bindings/src/core.h
+index 7ab1437..b9bdc2c 100644
+--- a/python/bindings/src/core.h
++++ b/python/bindings/src/core.h
+@@ -34,12 +34,12 @@
+ 
+ #pragma once
+ 
++#include <pybind11/pybind11.h>
+ #include <moveit/task_constructor/stage.h>
+ #include <moveit/task_constructor/container.h>
+ #include <moveit/task_constructor/cost_queue.h>
+ #include <moveit/task_constructor/cost_terms.h>
+ #include <moveit/utils/moveit_error_code.hpp>
+-#include <pybind11/smart_holder.h>
+ 
+ /** Trampoline classes to allow inheritance in Python (overriding virtual functions) */
+ 
+@@ -109,36 +109,3 @@ public:
+ }  // namespace task_constructor
+ }  // namespace moveit
+ 
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::solvers::PlannerInterface)
+-
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::SolutionBase)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::SubTrajectory)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(ordered<moveit::task_constructor::SolutionBaseConstPtr>)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::InterfaceState)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::core::MoveItErrorCode)
+-
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::CostTerm)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::TrajectoryCostTerm)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::cost::PathLength)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::cost::DistanceToReference)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::cost::TrajectoryDuration)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::cost::LinkMotion)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::cost::LinkRotation)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::cost::Clearance)
+-
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::Stage)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::PropagatingEitherWay)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::PropagatingForward)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::PropagatingBackward)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::Generator)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::MonitoringGenerator)
+-
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::ContainerBase)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::SerialContainer)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::ParallelContainerBase)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::Alternatives)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::Fallbacks)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::Merger)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::WrapperBase)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::Task)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(moveit::task_constructor::Introspection)
+diff --git a/python/bindings/src/module.cpp b/python/bindings/src/module.cpp
+index a797711..cd66917 100644
+--- a/python/bindings/src/module.cpp
++++ b/python/bindings/src/module.cpp
+@@ -32,7 +32,7 @@
+  *  POSSIBILITY OF SUCH DAMAGE.
+  *********************************************************************/
+ 
+-#include <pybind11/smart_holder.h>
++#include <pybind11/pybind11.h>
+ 
+ namespace moveit {
+ namespace python {
+diff --git a/python/bindings/src/solvers.cpp b/python/bindings/src/solvers.cpp
+index 7c6a12f..eebfa2e 100644
+--- a/python/bindings/src/solvers.cpp
++++ b/python/bindings/src/solvers.cpp
+@@ -46,12 +46,6 @@ using namespace py::literals;
+ using namespace moveit::task_constructor;
+ using namespace moveit::task_constructor::solvers;
+ 
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(PlannerInterface)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(PipelinePlanner)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(JointInterpolationPlanner)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(CartesianPath)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(MultiPlanner)
+-
+ namespace moveit {
+ namespace python {
+ 
+diff --git a/python/bindings/src/stages.cpp b/python/bindings/src/stages.cpp
+index 1dead16..f51308f 100644
+--- a/python/bindings/src/stages.cpp
++++ b/python/bindings/src/stages.cpp
+@@ -48,26 +48,6 @@ using namespace py::literals;
+ using namespace moveit::task_constructor;
+ using namespace moveit::task_constructor::stages;
+ 
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(ModifyPlanningScene)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(CurrentState)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(FixedState)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(ComputeIK)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(MoveTo)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(MoveRelative)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(Connect)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(FixCollisionObjects)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(GenerateGraspPose)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(GeneratePlacePose)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(GenerateRandomPose)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(GeneratePose)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(Pick)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(Place)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(SimpleGraspBase)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(SimpleGrasp)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(SimpleUnGrasp)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(PassThrough)
+-PYBIND11_SMART_HOLDER_TYPE_CASTERS(LimitSolutions)
+-
+ namespace moveit {
+ namespace python {
+ 
+@@ -369,7 +349,6 @@ void export_stages(pybind11::module& m) {
+ 		)")
+ 		.def(py::init<const std::string&>(), "name"_a = std::string("Generate Place Pose"));
+ 
+-
+ 	properties::class_<GenerateGraspPose, MonitoringGenerator>(m, "GenerateGraspPose", R"(
+ 			GenerateGraspPose stage derives from monitoring generator and can
+ 			be used to generate poses for grasping. Set the desired attributes

--- a/patch/ros-lyrical-moveit-task-constructor-core.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-core.patch
@@ -36,6 +36,20 @@ index 26c86ac..d5cd670 100644
  
  # install libs
  install(TARGETS ${PROJECT_NAME}_python_tools
+diff --git a/src/container.cpp b/src/container.cpp
+index febc00f..fded044 100644
+--- a/src/container.cpp
++++ b/src/container.cpp
+@@ -57,8 +57,7 @@ namespace moveit {
+ namespace task_constructor {
+ 
+ // for debugging of how children interfaces evolve over time
+-__attribute__((unused))  // silent unused-function warning
+-static void
++[[maybe_unused]] static void
+ printChildrenInterfaces(const ContainerBasePrivate& container, bool success, const Stage& creator,
+                         std::ostream& os = std::cerr) {
+ 	static unsigned int id = 0;
 diff --git a/src/cost_terms.cpp b/src/cost_terms.cpp
 index 9ddb94f..9896d36 100644
 --- a/src/cost_terms.cpp

--- a/patch/ros-lyrical-moveit-task-constructor-core.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-core.patch
@@ -194,3 +194,44 @@ index b64ce0a..a9eb8a0 100644
  		return false;
  	};
  
+diff --git a/src/stages/generate_place_pose.cpp b/src/stages/generate_place_pose.cpp
+index 76b9559..042882d 100644
+--- a/src/stages/generate_place_pose.cpp
++++ b/src/stages/generate_place_pose.cpp
+@@ -109,11 +109,11 @@ void GeneratePlacePose::compute() {
+ 	scene->getTransforms().transformPose(pose_msg.header.frame_id, target_pose, target_pose);
+ 
+ 	// spawn the nominal target object pose, considering flip about z and rotations about z-axis
+-	auto spawner = [&s, &scene, &ik_frame, this](const Eigen::Isometry3d& nominal, uint z_flips, uint z_rotations = 10) {
+-		for (uint flip = 0; flip <= z_flips; ++flip) {
++	auto spawner = [&s, &scene, &ik_frame, this](const Eigen::Isometry3d& nominal, uint32_t z_flips, uint32_t z_rotations = 10) {
++		for (uint32_t flip = 0; flip <= z_flips; ++flip) {
+ 			// flip about object's x-axis
+ 			Eigen::Isometry3d object = nominal * Eigen::AngleAxisd(flip * M_PI, Eigen::Vector3d::UnitX());
+-			for (uint i = 0; i < z_rotations; ++i) {
++			for (uint32_t i = 0; i < z_rotations; ++i) {
+ 				// rotate object at target pose about world's z-axis
+ 				Eigen::Vector3d pos = object.translation();
+ 				object.pretranslate(-pos)
+@@ -139,7 +139,7 @@ void GeneratePlacePose::compute() {
+ 		}
+ 	};
+ 
+-	uint z_flips = props.get<bool>("allow_z_flip") ? 1 : 0;
++	uint32_t z_flips = props.get<bool>("allow_z_flip") ? 1 : 0;
+ 	if (object && object->getShapes().size() == 1) {
+ 		switch (object->getShapes()[0]->type) {
+ 			case shapes::CYLINDER:
+diff --git a/test/test_stage.cpp b/test/test_stage.cpp
+index 1c0553c..39bfa92 100644
+--- a/test/test_stage.cpp
++++ b/test/test_stage.cpp
+@@ -36,7 +36,7 @@ TEST(Stage, registerCallbacks) {
+ 	StandaloneGeneratorMockup g{ PredefinedCosts::constant(0.0) };
+ 	g.init(getModel());
+ 
+-	uint called = 0;
++	uint32_t called = 0;
+ 	auto cb = [&called](const SolutionBase& /* s */) {
+ 		++called;
+ 		return true;

--- a/patch/ros-lyrical-moveit-task-constructor-core.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-core.patch
@@ -1,3 +1,29 @@
+diff --git a/include/moveit/task_constructor/introspection.h b/include/moveit/task_constructor/introspection.h
+index cf4dfb7..b7e26d5 100644
+--- a/include/moveit/task_constructor/introspection.h
++++ b/include/moveit/task_constructor/introspection.h
+@@ -111,7 +111,7 @@ private:
+ 	/// retrieve or set id of given stage
+ 	uint32_t stageId(const moveit::task_constructor::Stage* const s);
+ 	/// retrieve solution with given id
+-	const SolutionBase* solutionFromId(uint id) const;
++	const SolutionBase* solutionFromId(uint32_t id) const;
+ };
+ }  // namespace task_constructor
+ }  // namespace moveit
+diff --git a/include/moveit/task_constructor/properties.h b/include/moveit/task_constructor/properties.h
+index e217ad6..708a2fb 100644
+--- a/include/moveit/task_constructor/properties.h
++++ b/include/moveit/task_constructor/properties.h
+@@ -90,7 +90,7 @@ public:
+ 	/// exception thrown when trying to set a value not matching the declared type
+ 	class type_error;
+ 
+-	using SourceFlags = uint;
++	using SourceFlags = uint32_t;
+ 	/// function callback used to initialize property value from another PropertyMap
+ 	using InitializerFunction = std::function<boost::any(const PropertyMap&)>;
+ 
 diff --git a/python/bindings/CMakeLists.txt b/python/bindings/CMakeLists.txt
 index 26c86ac..d5cd670 100644
 --- a/python/bindings/CMakeLists.txt
@@ -48,6 +74,19 @@ index 9ddb94f..9896d36 100644
  	}
  
  	return distance_to_cost(distance);
+diff --git a/src/introspection.cpp b/src/introspection.cpp
+index d938f95..85292d9 100644
+--- a/src/introspection.cpp
++++ b/src/introspection.cpp
+@@ -214,7 +214,7 @@ void Introspection::publishAllSolutions(bool wait) {
+ 	};
+ }
+ 
+-const SolutionBase* Introspection::solutionFromId(uint id) const {
++const SolutionBase* Introspection::solutionFromId(uint32_t id) const {
+ 	auto it = impl->id_solution_bimap_.left.find(id);
+ 	if (it == impl->id_solution_bimap_.left.end())
+ 		return nullptr;
 diff --git a/src/properties.cpp b/src/properties.cpp
 index 8c001de..6fd0217 100644
 --- a/src/properties.cpp
@@ -60,6 +99,28 @@ index 8c001de..6fd0217 100644
  #include <functional>
  #include <rclcpp/logging.hpp>
  #include <rclcpp/clock.hpp>
+diff --git a/src/solvers/pipeline_planner.cpp b/src/solvers/pipeline_planner.cpp
+index 9e30131..18e6fb9 100644
+--- a/src/solvers/pipeline_planner.cpp
++++ b/src/solvers/pipeline_planner.cpp
+@@ -59,7 +59,7 @@ PipelinePlanner::PipelinePlanner(
+   , stopping_criterion_callback_(stopping_criterion_callback)
+   , solution_selection_function_(solution_selection_function) {
+ 	// Declare properties of the MotionPlanRequest
+-	properties().declare<uint>("num_planning_attempts", 1u, "number of planning attempts");
++	properties().declare<uint32_t>("num_planning_attempts", 1u, "number of planning attempts");
+ 	properties().declare<moveit_msgs::msg::WorkspaceParameters>(
+ 	    "workspace_parameters", moveit_msgs::msg::WorkspaceParameters(), "allowed workspace of mobile base?");
+ 
+@@ -182,7 +182,7 @@ PlannerInterface::Result PipelinePlanner::plan(const planning_scene::PlanningSce
+ 		request.planner_id = planner_id;
+ 		request.allowed_planning_time = timeout;
+ 		request.start_state.is_diff = true;  // we don't specify an extra start state
+-		request.num_planning_attempts = properties().get<uint>("num_planning_attempts");
++		request.num_planning_attempts = properties().get<uint32_t>("num_planning_attempts");
+ 		request.max_velocity_scaling_factor = properties().get<double>("max_velocity_scaling_factor");
+ 		request.max_acceleration_scaling_factor = properties().get<double>("max_acceleration_scaling_factor");
+ 		request.workspace_parameters = properties().get<moveit_msgs::msg::WorkspaceParameters>("workspace_parameters");
 diff --git a/src/stage.cpp b/src/stage.cpp
 index b64ce0a..a9eb8a0 100644
 --- a/src/stage.cpp

--- a/patch/ros-lyrical-moveit-task-constructor-core.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-core.patch
@@ -89,21 +89,53 @@ index 9ddb94f..9896d36 100644
  
  	return distance_to_cost(distance);
 diff --git a/src/introspection.cpp b/src/introspection.cpp
-index d938f95..85292d9 100644
+index d938f95..35d502a 100644
 --- a/src/introspection.cpp
 +++ b/src/introspection.cpp
-@@ -49,6 +49,10 @@
- #include <sstream>
+@@ -50,6 +50,14 @@
  #include <boost/bimap.hpp>
+ #include <rcutils/isalnum_no_locale.h>
  
 +#ifdef _WIN32
-+#include <winsock.h>
++	#include <winsock2.h>
++	#include <process.h>
++	#pragma comment(lib, "ws2_32.lib")
++#else
++	#include <unistd.h>
 +#endif
 +
- namespace ros {
- namespace names {
- bool isValidCharInName(char c);  // unfortunately this is not declared in ros/names.h
-@@ -214,7 +214,7 @@ void Introspection::publishAllSolutions(bool wait) {
+ static auto LOGGER = rclcpp::get_logger("introspection");
+ 
+ namespace moveit {
+@@ -60,12 +68,26 @@ std::string getTaskId(const TaskPrivate* task) {
+ 	static const std::string ALLOWED = "_/";
+ 	std::ostringstream oss;
+ 	char our_hostname[256] = { 0 };
++	#ifdef _WIN32
++	{
++		static bool wsa_initialised = false;
++		if (wsa_initialised) {
++			WSADATA wsaData;
++			WSAStartup(MAKEWORD(2, 2), &wsaData);
++			wsa_initialised = true;
++		}
++	}
++	#endif
+ 	gethostname(our_hostname, sizeof(our_hostname) - 1);
+ 	// Replace all invalid ROS-name chars with an underscore
+ 	std::replace_if(
+ 	    our_hostname, our_hostname + strlen(our_hostname),
+ 	    [](const char ch) { return !rcutils_isalnum_no_locale(ch) && ALLOWED.find(ch) == std::string::npos; }, '_');
+-	oss << our_hostname << "_" << getpid() << "_" << reinterpret_cast<std::size_t>(task);
++	#ifdef _WIN32
++		oss << our_hostname << "_" << _getpid() << "_" << reinterpret_cast<std::size_t>(task);
++	# else
++		oss << our_hostname << "_" << getpid() << "_" << reinterpret_cast<std::size_t>(task);
++	#endif
+ 	return oss.str();
+ }
+ }  // namespace
+@@ -214,7 +236,7 @@ void Introspection::publishAllSolutions(bool wait) {
  	};
  }
  

--- a/patch/ros-lyrical-moveit-task-constructor-visualization.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-visualization.patch
@@ -1,0 +1,47 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a220b3a..ae44a55 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,10 +19,10 @@ find_package(rviz_ogre_vendor REQUIRED)
+ add_definitions(-DBOOST_MATH_DISABLE_FLOAT128)
+ 
+ # Qt Stuff
+-find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
+-set(QT_LIBRARIES Qt5::Widgets)
++find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
++set(QT_LIBRARIES Qt6::Widgets)
+ macro(qt_wrap_ui)
+-	qt5_wrap_ui(${ARGN})
++	qt6_wrap_ui(${ARGN})
+ endmacro()
+ 
+ set(CMAKE_INCLUDE_CURRENT_DIR ON)
+diff --git a/motion_planning_tasks/src/remote_task_model.cpp b/motion_planning_tasks/src/remote_task_model.cpp
+index d28cfd6..8926cba 100644
+--- a/motion_planning_tasks/src/remote_task_model.cpp
++++ b/motion_planning_tasks/src/remote_task_model.cpp
+@@ -526,7 +526,7 @@ QVariant RemoteSolutionModel::data(const QModelIndex& index, int role) const {
+ 					return item.creation_rank;
+ 				case 1:
+ 					if (std::isinf(item.cost))
+-						return tr(u8"∞");
++						return tr("∞");
+ 					if (std::isnan(item.cost))
+ 						return QVariant();
+ 					return QLocale().toString(item.cost, 'f', 4);
+diff --git a/motion_planning_tasks/src/task_list_model.cpp b/motion_planning_tasks/src/task_list_model.cpp
+index 3cd6466..7c471d5 100644
+--- a/motion_planning_tasks/src/task_list_model.cpp
++++ b/motion_planning_tasks/src/task_list_model.cpp
+@@ -61,9 +61,9 @@ QVariant TaskListModel::horizontalHeader(int column, int role) {
+ 				case 0:
+ 					return tr("name");
+ 				case 1:
+-					return tr(u8"✓");
++					return tr("✓");
+ 				case 2:
+-					return tr(u8"✗");
++					return tr("✗");
+ 				case 3:
+ 					return tr("time");
+ 			}

--- a/patch/ros-lyrical-moveit-task-constructor-visualization.patch
+++ b/patch/ros-lyrical-moveit-task-constructor-visualization.patch
@@ -45,3 +45,82 @@ index 3cd6466..7c471d5 100644
  				case 3:
  					return tr("time");
  			}
+diff --git a/motion_planning_tasks/src/CMakeLists.txt b/motion_planning_tasks/src/CMakeLists.txt
+--- a/motion_planning_tasks/src/CMakeLists.txt
++++ b/motion_planning_tasks/src/CMakeLists.txt
+@@ -6,6 +6,8 @@
+ 	global_settings.ui
+ )
+ 
++qt6_add_resources(QRC_SOURCES resources.qrc)
++
+ add_library(${MOVEIT_LIB_NAME} SHARED
+ 	factory_model.cpp
+ 	icons.cpp
+@@ -22,7 +24,7 @@
+ 
+ 	${UIC_FILES}
+ 
+-	resources.qrc
++	${QRC_SOURCES}
+ )
+ 
+ set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+diff --git a/motion_planning_tasks/utils/flat_merge_proxy_model.h b/motion_planning_tasks/utils/flat_merge_proxy_model.h
+--- a/motion_planning_tasks/utils/flat_merge_proxy_model.h
++++ b/motion_planning_tasks/utils/flat_merge_proxy_model.h
+@@ -38,6 +38,16 @@
+ 
+ #include <QAbstractItemModel>
+ #include <QStringList>
++#if defined(_WIN32)
++#if defined(motion_planning_tasks_utils_EXPORTS)
++#define MOVEIT_RVIZ_UTILS_EXPORT __declspec(dllexport)
++#else
++#define MOVEIT_RVIZ_UTILS_EXPORT __declspec(dllimport)
++#endif
++#else
++#define MOVEIT_RVIZ_UTILS_EXPORT
++#endif
++
+ 
+ namespace moveit_rviz_plugin {
+ namespace utils {
+@@ -49,7 +59,7 @@
+  *  Removing top-level items will remove the whole embedded model if all top-level items from
+  *  this model are to be removed. Otherwise, removal is forwarded to the embedded model.
+  */
+-class FlatMergeProxyModel : public QAbstractItemModel
++class MOVEIT_RVIZ_UTILS_EXPORT FlatMergeProxyModel : public QAbstractItemModel
+ {
+ 	Q_OBJECT
+ 	Q_DECLARE_PRIVATE(FlatMergeProxyModel)
+diff --git a/motion_planning_tasks/utils/tree_merge_proxy_model.h b/motion_planning_tasks/utils/tree_merge_proxy_model.h
+--- a/motion_planning_tasks/utils/tree_merge_proxy_model.h
++++ b/motion_planning_tasks/utils/tree_merge_proxy_model.h
+@@ -38,6 +38,16 @@
+ 
+ #include <QAbstractItemModel>
+ #include <QStringList>
++#if defined(_WIN32)
++#if defined(motion_planning_tasks_utils_EXPORTS)
++#define MOVEIT_RVIZ_UTILS_EXPORT __declspec(dllexport)
++#else
++#define MOVEIT_RVIZ_UTILS_EXPORT __declspec(dllimport)
++#endif
++#else
++#define MOVEIT_RVIZ_UTILS_EXPORT
++#endif
++
+ 
+ namespace moveit_rviz_plugin {
+ namespace utils {
+@@ -48,7 +58,7 @@
+  *  Each embedded model becomes a top-level item (with a given name)
+  *  and all the model's top-level items will appear as its children.
+  */
+-class TreeMergeProxyModel : public QAbstractItemModel
++class MOVEIT_RVIZ_UTILS_EXPORT TreeMergeProxyModel : public QAbstractItemModel
+ {
+ 	Q_OBJECT
+ 	Q_DECLARE_PRIVATE(TreeMergeProxyModel)

--- a/patch/ros-lyrical-py-binding-tools.patch
+++ b/patch/ros-lyrical-py-binding-tools.patch
@@ -1,13 +1,83 @@
-From 954461c74ba6c3c7298c628e1ef5b8daaed694fc Mon Sep 17 00:00:00 2001
-From: Tobias Fischer <info@tobiasfischer.info>
-Date: Tue, 14 Jul 2026 07:31:29 +1000
-Subject: [PATCH] Rename module to module_ for C++20 compatibility
-
-This has been changed in pybind11 a while ago as far as I know
----
- include/py_binding_tools/ros_msg_typecasters.h | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
-
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e940609..a743203 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,8 @@
+ cmake_minimum_required(VERSION 3.5)
+ project(py_binding_tools)
+ 
++set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
++
+ find_package(ament_cmake REQUIRED)
+ find_package(ament_cmake_python REQUIRED)
+ find_package(rclcpp REQUIRED)
+@@ -13,9 +15,14 @@ add_library(${PROJECT_NAME} SHARED
+   src/ros_msg_typecasters.cpp
+   src/initializer.cpp
+ )
++
++include(GenerateExportHeader)
++generate_export_header(${PROJECT_NAME})
++
+ target_include_directories(${PROJECT_NAME}
+   PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+     $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
+ ament_target_dependencies(${PROJECT_NAME} rclcpp geometry_msgs pybind11)
+ 
+@@ -34,6 +41,8 @@ install(
+   DESTINATION include/${PROJECT_NAME}
+ )
+ 
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_export.h DESTINATION include)
++
+ _ament_cmake_python_register_environment_hook()
+ 
+ pybind11_add_module(rclcpp src/rclcpp.cpp)
+diff --git a/include/py_binding_tools/initializer.h b/include/py_binding_tools/initializer.h
+index c42e81a..9c23de2 100644
+--- a/include/py_binding_tools/initializer.h
++++ b/include/py_binding_tools/initializer.h
+@@ -36,6 +36,8 @@
+ #include <string>
+ #include <vector>
+ 
++#include <py_binding_tools_export.h>
++
+ namespace py_binding_tools
+ {
+ /** The constructor of this class ensures that rclcpp::init() has been called.
+@@ -48,7 +50,7 @@ public:
+   ~RCLInitializer();
+ };
+ 
+-void init(const std::vector<std::string>& args);
+-void shutdown();
++void PY_BINDING_TOOLS_EXPORT init(const std::vector<std::string>& args);
++void PY_BINDING_TOOLS_EXPORT shutdown();
+ 
+ }  // namespace py_binding_tools
+diff --git a/src/rclcpp.cpp b/src/rclcpp.cpp
+index 50232c9..794421d 100644
+--- a/src/rclcpp.cpp
++++ b/src/rclcpp.cpp
+@@ -38,12 +38,14 @@
+ #include <rclcpp/node.hpp>
+ #include <rclcpp/node_options.hpp>
+ 
++#include <py_binding_tools_export.h>
++
+ namespace py = pybind11;
+ using namespace py_binding_tools;
+ 
+ namespace py_binding_tools
+ {
+-void add_node(const rclcpp::Node::SharedPtr& node);
++void PY_BINDING_TOOLS_EXPORT add_node(const rclcpp::Node::SharedPtr& node);
+ }
+ 
+ namespace
 diff --git a/include/py_binding_tools/ros_msg_typecasters.h b/include/py_binding_tools/ros_msg_typecasters.h
 index 30c5edc..b85fd21 100644
 --- a/include/py_binding_tools/ros_msg_typecasters.h

--- a/patch/ros-lyrical-py-binding-tools.patch
+++ b/patch/ros-lyrical-py-binding-tools.patch
@@ -1,0 +1,41 @@
+From 954461c74ba6c3c7298c628e1ef5b8daaed694fc Mon Sep 17 00:00:00 2001
+From: Tobias Fischer <info@tobiasfischer.info>
+Date: Tue, 14 Jul 2026 07:31:29 +1000
+Subject: [PATCH] Rename module to module_ for C++20 compatibility
+
+This has been changed in pybind11 a while ago as far as I know
+---
+ include/py_binding_tools/ros_msg_typecasters.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/py_binding_tools/ros_msg_typecasters.h b/include/py_binding_tools/ros_msg_typecasters.h
+index 30c5edc..b85fd21 100644
+--- a/include/py_binding_tools/ros_msg_typecasters.h
++++ b/include/py_binding_tools/ros_msg_typecasters.h
+@@ -102,7 +102,7 @@ struct type_caster<rclcpp::Time>
+   // convert from rclcpp::Time to rclpy::Time
+   static handle cast(const rclcpp::Time& src, return_value_policy /* policy */, handle /* parent */)
+   {
+-    object Time = module::import("rclpy.time").attr("Time");
++    object Time = module_::import("rclpy.time").attr("Time");
+     object ClockType = Time().attr("clock_type").attr("__class__");
+ 
+     return Time(arg("nanoseconds") = src.nanoseconds(),
+@@ -131,7 +131,7 @@ struct RosMsgTypeCaster
+     object cls = py_binding_tools::createMessageClass(rosidl_generator_traits::name<T>());
+ 
+     // deserialize into python object
+-    module rclpy = module::import("rclpy.serialization");
++    module_ rclpy = module_::import("rclpy.serialization");
+     object msg = rclpy.attr("deserialize_message")(buf, cls);
+ 
+     return msg.release();
+@@ -145,7 +145,7 @@ struct RosMsgTypeCaster
+       return false;
+ 
+     // serialize src into python buffer
+-    module rclpy = module::import("rclpy.serialization");
++    module_ rclpy = module_::import("rclpy.serialization");
+     bytes buf = rclpy.attr("serialize_message")(src);
+ 
+     // deserialize into C++ object

--- a/patch/ros-lyrical-py-binding-tools.patch
+++ b/patch/ros-lyrical-py-binding-tools.patch
@@ -30,7 +30,7 @@ index e940609..a743203 100644
    DESTINATION include/${PROJECT_NAME}
  )
  
-+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_export.h DESTINATION include)
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_export.h DESTINATION include/${PROJECT_NAME})
 +
  _ament_cmake_python_register_environment_hook()
  

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -99,6 +99,7 @@ packages_select_by_deps:
   - moveit-ros-control-interface
   - moveit-ros-trajectory-cache
   - moveit-servo
+  - moveit-task-constructor-demo
   - moveit-visual-tools
   - nav2_bringup
   - navigation2


### PR DESCRIPTION
This PR adds the six MoveIt Task Constructor packages to ros-lyrical:

1. moveit-task-constructor-core
2. moveit-task-constructor-capabilities
3. moveit-task-constructor-msgs
4. moveit-task-constructor-visualization
5. moveit-task-constructor-demo
6. rviz-marker-tools

 along with patches needed to build `moveit-task-constructor-core` and `moveit-task-constructor-visualization`.