### PR TITLE
Add teleop_tools packages

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -91,8 +91,11 @@ packages_select_by_deps:
   - gtsam
   - gz_ros2_control
   - gz_ros2_control_demos
+  - joy_teleop
+  - key_teleop
   - lanelet2
   - magic_enum
+  - mouse_teleop
   - moveit
   - moveit-chomp-optimizer-adapter  # Requested in https://www.linkedin.com/feed/update/urn:li:activity:7346559234177703938/
   - moveit-planners-chomp
@@ -133,6 +136,7 @@ packages_select_by_deps:
   - simulation
   - slam_toolbox
   - teleop
+  - teleop-tools
   - turtlebot3
   - twist_mux  # requested in https://github.com/RoboStack/ros-humble/issues/249
   - twist_stamper  # Requested in https://github.com/RoboStack/ros-rolling/issues/12


### PR DESCRIPTION
This PR adds the following packages from teleop_tools (https://github.com/ros-teleop/teleop_tools) to ros-lyrical

- joy_teleop
- mouse_teleop
- key_teleop
- teleop_tools_msgs
- teleop_tools