### PR TITLE
Add point_cloud_transport_plugins and point_cloud_transport_py

### DIFF
--- a/patch/ros-lyrical-zstd-point-cloud-transport.patch
+++ b/patch/ros-lyrical-zstd-point-cloud-transport.patch
@@ -1,0 +1,52 @@
+diff --git a/include/zstd_point_cloud_transport/zstd_publisher.hpp b/include/zstd_point_cloud_transport/zstd_publisher.hpp
+index 0e545c3..4ef6ca2 100644
+--- a/include/zstd_point_cloud_transport/zstd_publisher.hpp
++++ b/include/zstd_point_cloud_transport/zstd_publisher.hpp
+@@ -55,6 +55,8 @@ class ZstdPublisher
+ public:
+   ZstdPublisher();
+ 
++  ~ZstdPublisher() override;
++
+   void declareParameters(const std::string & base_topic) override;
+ 
+   std::string getDataType() const override;
+diff --git a/include/zstd_point_cloud_transport/zstd_subscriber.hpp b/include/zstd_point_cloud_transport/zstd_subscriber.hpp
+index b5828d3..bac0a2c 100644
+--- a/include/zstd_point_cloud_transport/zstd_subscriber.hpp
++++ b/include/zstd_point_cloud_transport/zstd_subscriber.hpp
+@@ -51,7 +51,7 @@ class ZstdSubscriber
+ public:
+   ZstdSubscriber();
+ 
+-  std::string getTransportName() const override;
++  ~ZstdSubscriber() override;
+ 
+   void declareParameters() override;
+ 
+diff --git a/src/zstd_publisher.cpp b/src/zstd_publisher.cpp
+index da1e3f5..1126c56 100644
+--- a/src/zstd_publisher.cpp
++++ b/src/zstd_publisher.cpp
+@@ -41,6 +41,8 @@
+ namespace zstd_point_cloud_transport
+ {
+ 
++ZstdPublisher::~ZstdPublisher() = default;
++
+ ZstdPublisher::ZstdPublisher()
+ {
+   this->zstd_context_ = ZSTD_createCCtx();
+diff --git a/src/zstd_subscriber.cpp b/src/zstd_subscriber.cpp
+index ec95a78..f1af2ad 100644
+--- a/src/zstd_subscriber.cpp
++++ b/src/zstd_subscriber.cpp
+@@ -42,6 +42,8 @@
+ 
+ namespace zstd_point_cloud_transport
+ {
++
++ZstdSubscriber::~ZstdSubscriber() = default;
+ ZstdSubscriber::ZstdSubscriber()
+ {
+   this->zstd_context_ = ZSTD_createDCtx();

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -109,7 +109,6 @@ packages_select_by_deps:
   - nmea-navsat-driver
   - perception
   - persist-parameter-server
-  - point_cloud_transport_plugins
   - point_cloud_transport_py
   - polygon_msgs
   - proxsuite
@@ -207,6 +206,7 @@ packages_select_by_deps:
       - ouster_ros  # TODO on windows: cannot open pcl_io.lib
       - pinocchio
       - plotjuggler-ros
+      - point_cloud_transport_plugins
       - pointcloud-to-laserscan
       - rplidar_ros
       - rqt_mocap4r2_control

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -109,6 +109,8 @@ packages_select_by_deps:
   - nmea-navsat-driver
   - perception
   - persist-parameter-server
+  - point_cloud_transport_plugins
+  - point_cloud_transport_py
   - polygon_msgs
   - proxsuite
   - py-trees


### PR DESCRIPTION
## Goal

Add the `point_cloud_transport_plugins` compression plugins and the
`point_cloud_transport_py` Python bindings to the robostack-lyrical distribution.

## Description

The core `point_cloud_transport` package is already built in the RoboStack Lyrical
channel, but the compression plugins and the Python bindings are currently missing.

`point_cloud_transport_plugins` is a metapackage providing the codec plugins
(`draco`, `zlib`, `zstd`) used for low-bandwidth transport of PointCloud2 messages,
along with `point_cloud_interfaces`. `point_cloud_transport_py` exposes the
transport to Python. These are required by downstream projects that rely on
compressed point cloud pipelines.

## Changes

- Added `point_cloud_transport_py` to the Lyrical build selection.
- Added `point_cloud_transport_plugins` to the Lyrical build selection.
- Verified successful build on linux-64 using `vinca` (no patches needed).

## License

`point_cloud_transport` and its plugins are licensed under the Apache-2.0 / BSD-3-Clause
licenses (per the upstream packages).

## Notes

Build tested locally on linux-64. macOS and Windows will be verified by CI.