### PR TITLE
Update pixi and rattler-build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,9 @@ jobs:
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
-    - uses: prefix-dev/setup-pixi@v0.9.4
+    - uses: prefix-dev/setup-pixi@v0.10.0
       with:
+        pixi-version: v0.75.0
         frozen: true
 
     - name: Generate recipes for linux-64

--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -40,8 +40,9 @@ jobs:
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
-    - uses: prefix-dev/setup-pixi@v0.9.4
+    - uses: prefix-dev/setup-pixi@v0.10.0
       with:
+        pixi-version: v0.75.0
         frozen: true
 
     - name: Long paths workarounds for win-64

--- a/pixi.lock
+++ b/pixi.lock
@@ -63,7 +63,7 @@ environments:
       - conda: https://repo.prefix.dev/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
       - conda: https://repo.prefix.dev/conda-forge/osx-64/openssl-3.6.3-hc881268_0.conda
       - conda: https://repo.prefix.dev/conda-forge/osx-64/python-3.14.6-h7c6738f_101_cp314.conda
-      - conda: https://repo.prefix.dev/conda-forge/osx-64/rattler-build-0.57.2-h4728fb8_1.conda
+      - conda: https://repo.prefix.dev/conda-forge/osx-64/rattler-build-0.72.2-h6193a51_0.conda
       - conda: https://repo.prefix.dev/conda-forge/osx-64/rattler-index-0.30.3-hbc4d974_0.conda
       - conda: https://repo.prefix.dev/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
       - conda: https://repo.prefix.dev/conda-forge/osx-64/rhash-1.4.6-h6e16a3a_1.conda
@@ -124,7 +124,7 @@ environments:
       - conda: https://repo.prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://repo.prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
       - conda: https://repo.prefix.dev/conda-forge/osx-arm64/python-3.14.6-h156bc91_101_cp314.conda
-      - conda: https://repo.prefix.dev/conda-forge/osx-arm64/rattler-build-0.57.2-h6fdd925_1.conda
+      - conda: https://repo.prefix.dev/conda-forge/osx-arm64/rattler-build-0.72.2-h20b3172_0.conda
       - conda: https://repo.prefix.dev/conda-forge/osx-arm64/rattler-index-0.30.3-hcb0414c_0.conda
       - conda: https://repo.prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://repo.prefix.dev/conda-forge/osx-arm64/rhash-1.4.6-h5505292_1.conda
@@ -189,7 +189,7 @@ environments:
       - conda: https://repo.prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
       - conda: https://repo.prefix.dev/conda-forge/linux-64/patchelf-0.18.0-h3f2d84a_2.conda
       - conda: https://repo.prefix.dev/conda-forge/linux-64/python-3.14.6-habeac84_101_cp314.conda
-      - conda: https://repo.prefix.dev/conda-forge/linux-64/rattler-build-0.57.2-he64ecbb_1.conda
+      - conda: https://repo.prefix.dev/conda-forge/linux-64/rattler-build-0.72.2-ha759004_0.conda
       - conda: https://repo.prefix.dev/conda-forge/linux-64/rattler-index-0.30.3-h58ba7e0_0.conda
       - conda: https://repo.prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://repo.prefix.dev/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
@@ -258,7 +258,7 @@ environments:
       - conda: https://repo.prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
       - conda: https://repo.prefix.dev/conda-forge/linux-aarch64/patchelf-0.18.0-h5ad3122_2.conda
       - conda: https://repo.prefix.dev/conda-forge/linux-aarch64/python-3.14.6-hc679e19_101_cp314.conda
-      - conda: https://repo.prefix.dev/conda-forge/linux-aarch64/rattler-build-0.57.2-hb434046_1.conda
+      - conda: https://repo.prefix.dev/conda-forge/linux-aarch64/rattler-build-0.72.2-h1d7f6d8_0.conda
       - conda: https://repo.prefix.dev/conda-forge/linux-aarch64/rattler-index-0.30.3-h9889dc0_0.conda
       - conda: https://repo.prefix.dev/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://repo.prefix.dev/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
@@ -321,7 +321,7 @@ environments:
       - conda: https://repo.prefix.dev/conda-forge/win-64/m2-conda-epoch-20250515-0_x86_64.conda
       - conda: https://repo.prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
       - conda: https://repo.prefix.dev/conda-forge/win-64/python-3.14.6-h4b44e0e_101_cp314.conda
-      - conda: https://repo.prefix.dev/conda-forge/win-64/rattler-build-0.57.2-h18a1a76_1.conda
+      - conda: https://repo.prefix.dev/conda-forge/win-64/rattler-build-0.72.2-he94b42d_0.conda
       - conda: https://repo.prefix.dev/conda-forge/win-64/rattler-index-0.30.3-h91801bb_0.conda
       - conda: https://repo.prefix.dev/conda-forge/win-64/tk-8.6.13-h967ab96_3.conda
       - conda: https://repo.prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
@@ -843,22 +843,22 @@ packages:
   size: 36869055
   timestamp: 1784910110714
   python_site_packages_path: lib/python3.14/site-packages
-- conda: https://repo.prefix.dev/conda-forge/linux-64/rattler-build-0.57.2-he64ecbb_1.conda
-  sha256: 7050df6859e1f3c1223dead79b1f4aa5b92f7519db7ad7cb5982d87fd2999852
-  md5: 4d9aed902b2afb49657a4e85f493aedd
+- conda: https://repo.prefix.dev/conda-forge/linux-64/rattler-build-0.72.2-ha759004_0.conda
+  sha256: ef9a5c754406f7975bae7e0a7a8502006a5c6c10f6e066ce794c629d7b38c00b
+  md5: 59bfc06d53aa3d1fddddb1c668fe034e
   depends:
   - patchelf
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - libgcc >=14
-  - openssl >=3.5.5,<4.0a0
+  - openssl >=3.5.7,<4.0a0
   constrains:
   - __glibc >=2.17
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
   run_exports: {}
-  size: 19271452
-  timestamp: 1770649397185
+  size: 19680703
+  timestamp: 1785543768429
 - conda: https://repo.prefix.dev/conda-forge/linux-64/rattler-index-0.30.3-h58ba7e0_0.conda
   sha256: 18271b2a3a02c579354f65eac2bd5857c5f53595641b8062255c4dbafe6e3ae9
   md5: 63837509b18119660b18d0ba8c766128
@@ -1389,21 +1389,21 @@ packages:
   size: 34850010
   timestamp: 1784909900639
   python_site_packages_path: lib/python3.14/site-packages
-- conda: https://repo.prefix.dev/conda-forge/linux-aarch64/rattler-build-0.57.2-hb434046_1.conda
-  sha256: 51a369b6cfe24fa0f8f7a7ea9bb77158f8806f43b196ce5a30a61892092afe64
-  md5: 9f14051749d3c1b3e0318a6b8a54b0ca
+- conda: https://repo.prefix.dev/conda-forge/linux-aarch64/rattler-build-0.72.2-h1d7f6d8_0.conda
+  sha256: ff9e00a322241a25a882b1a78ff3ace431765975d47e52d675e03209a920478f
+  md5: e3cfc6057dfab19ae2e2f1e6c5b193cf
   depends:
   - patchelf
   - libgcc >=14
-  - openssl >=3.5.5,<4.0a0
+  - libstdcxx >=14
+  - openssl >=3.5.7,<4.0a0
   constrains:
   - __glibc >=2.17
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
   run_exports: {}
-  size: 19846896
-  timestamp: 1770649419199
+  size: 19125853
+  timestamp: 1785543793045
 - conda: https://repo.prefix.dev/conda-forge/linux-aarch64/rattler-index-0.30.3-h9889dc0_0.conda
   sha256: 5ad9d158efb39a0133a906df7df88e0b7436e398d807474c10ba44eae759f5af
   md5: 8b3e5d797336276400ed6685b64ec64b
@@ -1893,19 +1893,19 @@ packages:
   size: 14497574
   timestamp: 1784958042787
   python_site_packages_path: lib/python3.14/site-packages
-- conda: https://repo.prefix.dev/conda-forge/osx-64/rattler-build-0.57.2-h4728fb8_1.conda
-  sha256: 5ec581b4f39060c1b90687627f4b0bf04ee62d405f43072de7c83a46a9448324
-  md5: 286416d9d4b0c9fedd90e0ed56be240c
+- conda: https://repo.prefix.dev/conda-forge/osx-64/rattler-build-0.72.2-h6193a51_0.conda
+  sha256: 1c9459077c5c868522b9ef2ed7d5c375b74f61143378d71d2c27a0d4c2780fbe
+  md5: f8e7a65fee72591fcc0c0f5c62f74a82
   depends:
-  - __osx >=10.13
+  - __osx >=11.0
+  - libcxx >=19
   constrains:
-  - __osx >=10.13
+  - __osx >=11.0
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
   run_exports: {}
-  size: 17788466
-  timestamp: 1770649457751
+  size: 19220256
+  timestamp: 1785543873696
 - conda: https://repo.prefix.dev/conda-forge/osx-64/rattler-index-0.30.3-hbc4d974_0.conda
   sha256: 117318e70c35426be1bf0a1986455af77c9ec8abffe5de72b7eead381e373e22
   md5: f45f1b7f42fafecad59f0cba777d463c
@@ -2318,19 +2318,19 @@ packages:
   size: 14035244
   timestamp: 1784909523029
   python_site_packages_path: lib/python3.14/site-packages
-- conda: https://repo.prefix.dev/conda-forge/osx-arm64/rattler-build-0.57.2-h6fdd925_1.conda
-  sha256: 7fa90a0d2ecb767796cadfa6f1384e52229c9cdd10c11ce49a3428048f64b91c
-  md5: a28d853fd6fff4914e3248343b158837
+- conda: https://repo.prefix.dev/conda-forge/osx-arm64/rattler-build-0.72.2-h20b3172_0.conda
+  sha256: 75d671b46a790dd2ed45c7a713d45b76772bd23ca236c17c0f5e54adb158ac91
+  md5: 558030b5c335b1041be073638f53c1a1
   depends:
   - __osx >=11.0
+  - libcxx >=19
   constrains:
   - __osx >=11.0
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
   run_exports: {}
-  size: 16253611
-  timestamp: 1770649407683
+  size: 17696068
+  timestamp: 1785543806251
 - conda: https://repo.prefix.dev/conda-forge/osx-arm64/rattler-index-0.30.3-hcb0414c_0.conda
   sha256: a467183f2f2daf2869eed4f7e58a3e8a6d92837b4048552c244fe8aa78dbdb5c
   md5: 40635eb678901d1cc20e1140032260f2
@@ -2706,19 +2706,18 @@ packages:
   size: 18338767
   timestamp: 1784911044838
   python_site_packages_path: Lib/site-packages
-- conda: https://repo.prefix.dev/conda-forge/win-64/rattler-build-0.57.2-h18a1a76_1.conda
-  sha256: 9b575a5eaae1c427251d75ad36f6707f541e59056adcde35fca410c7f5aa29aa
-  md5: 545404bf30528513fd12c111b01c95a0
+- conda: https://repo.prefix.dev/conda-forge/win-64/rattler-build-0.72.2-he94b42d_0.conda
+  sha256: bd96fffbab89fe61a8377264c5c941435d96ea513835855b514b27454e3f6788
+  md5: 252bd358d47db8684a6734e279f92f91
   depends:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
   run_exports: {}
-  size: 16311008
-  timestamp: 1770649439173
+  size: 20390390
+  timestamp: 1785543839782
 - conda: https://repo.prefix.dev/conda-forge/win-64/rattler-index-0.30.3-h91801bb_0.conda
   sha256: ef8e53ad5c4c7bdc465ed5853d44fc26ca60a1b1b48838962814f5eef2081258
   md5: 161257c1595bb9361673d434a680bcdd

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,9 +11,8 @@ libc = { family="glibc", version="2.17" }
 
 [dependencies]
 python = ">=3.14.0,<3.15"
-# Include the latest rattler-build fixes w.r.t. to patches handling
-# rattler-build regression, pinning to 0.57
-rattler-build = "<0.58.0"
+# Include the latest rattler-build fixes with respect to patch handling.
+rattler-build = ">=0.72.2"
 cmake = "<4.0"
 setuptools = "<82.0"
 rattler-index = ">=0.27.16"


### PR DESCRIPTION
## Summary

- update setup-pixi to v0.10.0
- pin CI to pixi v0.75.0
- update rattler-build to v0.72.2 and refresh the lockfile

## Validation

- `pixi install --frozen`
- `pixi run rattler-build --version`
- parsed both workflow files as YAML
- `git diff --check`

## Patch-check investigation

The failures in #22 reproduce with rattler-build 0.72.2. They are stale patches after the snapshot update rather than a rattler-build regression: `sbg_driver` 3.4.0 conflicts on all platforms, while `slam_toolbox` 2.10.0 additionally conflicts on Windows. The new `navmap_ros` patch applies successfully.