### PR TITLE
Expand common ROS package coverage

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -76,6 +76,8 @@ packages_select_by_deps:
   - battery_state_broadcaster
   - behaviortree_cpp
   - better_launch
+  - bond_core
+  - bondcpp
   - can_msgs
   - cm_executors
   - data_tamer_cpp  # Requested in https://github.com/RoboStack/ros-humble/issues/325
@@ -91,6 +93,7 @@ packages_select_by_deps:
   - gtsam
   - gz_ros2_control
   - gz_ros2_control_demos
+  - imu_tools
   - joy_teleop
   - key_teleop
   - lanelet2
@@ -105,6 +108,8 @@ packages_select_by_deps:
   - moveit-task-constructor-demo
   - moveit-visual-tools
   - nav2_bringup
+  - nav2_minimal_tb3_sim
+  - nav2_minimal_tb4_sim
   - navigation2
   - nmea-navsat-driver
   - perception
@@ -115,6 +120,7 @@ packages_select_by_deps:
   - py-trees-ros
   - py-trees-ros-interfaces
   - py-trees-ros-viewer
+  - py_trees_ros_tutorials
   - rmw_zenoh_cpp  # requested in https://github.com/RoboStack/ros-humble/issues/252
   - robot
   - robot-localization
@@ -131,6 +137,8 @@ packages_select_by_deps:
   - rosidl_buffer_backend
   - rosidl_buffer_backend_registry
   - rosidl_buffer_py
+  - rqt_robot_monitor
+  - rqt_runtime_monitor
   - rviz_visual_tools
   - sbg_driver
   - simulation
@@ -138,6 +146,7 @@ packages_select_by_deps:
   - teleop
   - teleop-tools
   - turtlebot3
+  - turtlebot3_simulations
   - twist_mux  # requested in https://github.com/RoboStack/ros-humble/issues/249
   - twist_stamper  # Requested in https://github.com/RoboStack/ros-rolling/issues/12
   - ublox
@@ -205,6 +214,7 @@ packages_select_by_deps:
       - ouster_ros  # TODO on windows: cannot open pcl_io.lib
       - pinocchio
       - plotjuggler-ros
+      - point_cloud_transport_plugins
       - pointcloud-to-laserscan
       - rplidar_ros
       - rqt_mocap4r2_control
@@ -213,6 +223,7 @@ packages_select_by_deps:
       - rviz_satellite
       - serial_driver
       - swri_console  # Until sync of: https://github.com/ros/rosdistro/pull/49750
+      - trac_ik
       - velodyne
 
 patch_dir: patch

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -171,6 +171,7 @@ packages_select_by_deps:
       - apriltag_ros  # Depends on camera_ros
       - camera_ros  # Depends on libcamera that is only available on linux
       - livox_ros_driver2
+      - point_cloud_transport_plugins  # zstd plugin has unresolved symbols on macOS
       - py_binding_tools
       - swri_serial_util  # Serial communication only implemented for linux
       - v4l2_camera  # Depends on v4l that is only available on linux
@@ -214,7 +215,6 @@ packages_select_by_deps:
       - ouster_ros  # TODO on windows: cannot open pcl_io.lib
       - pinocchio
       - plotjuggler-ros
-      - point_cloud_transport_plugins
       - pointcloud-to-laserscan
       - rplidar_ros
       - rqt_mocap4r2_control


### PR DESCRIPTION
## Summary

Expand Lyrical coverage with packages that are released in the current snapshot, are selected by Jazzy or Rolling, and were not yet present in the Lyrical channel:

- Bond (`bond_core`, `bondcpp`)
- IMU tools
- Nav2 minimal TurtleBot 3/4 simulations
- point cloud transport plugins
- py_trees ROS tutorials
- rqt robot/runtime monitors
- TRAC-IK
- TurtleBot 3 simulations

This selects 12 top-level entries and produces 25 new packages with their dependencies. Point-cloud transport is Linux-only because the zstd plugin has unresolved vtable symbols on macOS; TRAC-IK remains disabled on Windows.

## Validation

- compared Lyrical selections/channel contents with current Jazzy, Kilted, and Rolling configs
- generated 30 candidate recipes, then excluded four groups with known unresolved build issues (`geodesy`, `udp_driver`, `vision_msgs_rviz_plugins`, and `web_video_server`)
- built all 25 remaining generated packages successfully for `linux-64`
- `pixi run sort --check`
- `git diff --check`