### PR TITLE
Update point cloud transport packages and fix macOS

### DIFF
--- a/rosdistro_snapshot.yaml
+++ b/rosdistro_snapshot.yaml
@@ -1068,9 +1068,9 @@ domain_coordinator:
   url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
   version: 0.15.8
 draco_point_cloud_transport:
-  tag: release/lyrical/draco_point_cloud_transport/6.1.0-3
+  tag: release/lyrical/draco_point_cloud_transport/6.2.0-1
   url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-  version: 6.1.0
+  version: 6.2.0
 dual_arm_panda_moveit_config:
   tag: release/lyrical/dual_arm_panda_moveit_config/3.1.1-3
   url: https://github.com/ros2-gbp/moveit_resources-release.git
@@ -3564,9 +3564,9 @@ pluginlib:
   url: https://github.com/ros2-gbp/pluginlib-release.git
   version: 5.8.4
 point_cloud_interfaces:
-  tag: release/lyrical/point_cloud_interfaces/6.1.0-3
+  tag: release/lyrical/point_cloud_interfaces/6.2.0-1
   url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-  version: 6.1.0
+  version: 6.2.0
 point_cloud_msg_wrapper:
   tag: release/lyrical/point_cloud_msg_wrapper/1.0.7-6
   url: https://github.com/ros2-gbp/point_cloud_msg_wrapper-release.git
@@ -3576,9 +3576,9 @@ point_cloud_transport:
   url: https://github.com/ros2-gbp/point_cloud_transport-release.git
   version: 5.4.2
 point_cloud_transport_plugins:
-  tag: release/lyrical/point_cloud_transport_plugins/6.1.0-3
+  tag: release/lyrical/point_cloud_transport_plugins/6.2.0-1
   url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-  version: 6.1.0
+  version: 6.2.0
 point_cloud_transport_py:
   tag: release/lyrical/point_cloud_transport_py/5.4.2-1
   url: https://github.com/ros2-gbp/point_cloud_transport-release.git
@@ -6060,9 +6060,9 @@ zenoh_security_tools:
   url: https://github.com/ros2-gbp/rmw_zenoh-release.git
   version: 0.10.4
 zlib_point_cloud_transport:
-  tag: release/lyrical/zlib_point_cloud_transport/6.1.0-3
+  tag: release/lyrical/zlib_point_cloud_transport/6.2.0-1
   url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-  version: 6.1.0
+  version: 6.2.0
 zmqpp_vendor:
   tag: release/lyrical/zmqpp_vendor/0.0.2-5
   url: https://github.com/ros2-gbp/zmqpp_vendor-release.git
@@ -6076,6 +6076,6 @@ zstd_image_transport:
   url: https://github.com/ros2-gbp/image_transport_plugins-release.git
   version: 6.2.5
 zstd_point_cloud_transport:
-  tag: release/lyrical/zstd_point_cloud_transport/6.1.0-3
+  tag: release/lyrical/zstd_point_cloud_transport/6.2.0-1
   url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-  version: 6.1.0
+  version: 6.2.0

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -115,6 +115,7 @@ packages_select_by_deps:
   - perception
   - persist-parameter-server
   - pick_ik
+  - point_cloud_transport_py
   - polygon_msgs
   - proxsuite
   - py-trees

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -172,7 +172,6 @@ packages_select_by_deps:
       - apriltag_ros  # Depends on camera_ros
       - camera_ros  # Depends on libcamera that is only available on linux
       - livox_ros_driver2
-      - point_cloud_transport_plugins  # zstd plugin has unresolved symbols on macOS
       - py_binding_tools
       - swri_serial_util  # Serial communication only implemented for linux
       - v4l2_camera  # Depends on v4l that is only available on linux
@@ -216,6 +215,7 @@ packages_select_by_deps:
       - ouster_ros  # TODO on windows: cannot open pcl_io.lib
       - pinocchio
       - plotjuggler-ros
+      - point_cloud_transport_plugins  # Not yet supported on Windows
       - pointcloud-to-laserscan
       - rplidar_ros
       - rqt_mocap4r2_control


### PR DESCRIPTION
## Summary

- update the point cloud transport plugin family from 6.1.0 to the current upstream Lyrical release, 6.2.0
- enable the plugins on macOS again while retaining the existing Windows exclusion
- add the `point_cloud_transport_py` Python bindings requested in #23

## Why this fixes the failure

The 6.1.0 `ZstdSubscriber` header declared `getTransportName()` but the API update removed its definition. Linux allowed the unresolved symbol in the shared library, while the macOS linker correctly rejected the incomplete vtable.

Upstream fixed this in ros-perception/point_cloud_transport_plugins#84 by removing the obsolete override and explicitly linking the CMake zstd target. That fix is included in 6.2.0 and is already released into the Lyrical rosdistro as `6.2.0-1`.

## Validation

- verified all five `6.2.0-1` release tags
- generated recipes with the new `zstd_cmake_module` dependency
- built all five updated plugin packages and `point_cloud_transport_py` successfully for `linux-64`
- `pixi run sort --check`
- `git diff --check`

Supersedes #23 while retaining @baradejoo as co-author of the Python bindings commit.
