### PR TITLE
Add MOLA and MRPT packages

### DIFF
--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -103,7 +103,11 @@ jobs:
     - name: Delete specific outdated cache entries
       shell: bash -l {0}
       run: |
-        # rm -rf ${{ matrix.folder_cache }}/ros-lyrical-pcl-conversions* 2>/dev/null || true
+        # Rebuild the split MRPT libraries on Linux so their run exports use
+        # the glibc-2.28-compatible libudev pin.
+        if [[ "${{ matrix.platform }}" == linux-* ]]; then
+          rm -rf ${{ matrix.folder_cache }}/ros-lyrical-mrpt-* 2>/dev/null || true
+        fi
         mkdir -p ${{ matrix.folder_cache }}
         pixi run rattler-index fs ${{ matrix.folder_cache }}/.. --force
 

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -84,6 +84,9 @@ mrpt2:
 mp2p_icp:
   add_host: ["ros-lyrical-mola-common", "ros-lyrical-mola-imu-preintegration", "ros-lyrical-mrpt-libbase", "ros-lyrical-mrpt-libgui", "ros-lyrical-mrpt-libtclap", "ros-lyrical-mrpt-libmaps", "ros-lyrical-mrpt-libobs", "ros-lyrical-mrpt-libposes", "tbb"]
   add_run: ["ros-lyrical-mola-common", "ros-lyrical-mola-imu-preintegration", "ros-lyrical-mrpt-libbase", "ros-lyrical-mrpt-libgui", "ros-lyrical-mrpt-libtclap", "ros-lyrical-mrpt-libmaps", "ros-lyrical-mrpt-libobs", "ros-lyrical-mrpt-libposes", "tbb"]
+mrpt_libmaps:
+  add_host: ["octomap"]
+  add_run: ["octomap"]
 ros1_rosbag_storage_vendor:
   add_host: ["ros-noetic-roscpp", "ros-noetic-roslz4", "ros-noetic-rostest"]
   add_run: ["ros-noetic-roscpp", "ros-noetic-roslz4"]

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -81,6 +81,9 @@ mrpt2:
   add_host:  ["assimp", "octomap", "tinyxml2", "libboost-devel", "jsoncpp", "gtest", "libboost-python-devel", "libdc1394", "xorg-libxcomposite", "libftdi", "ros-lyrical-octomap"]
   add_run:   ["assimp", "octomap", "tinyxml2", "libboost-devel", "jsoncpp", "gtest", "libboost-python-devel", "libdc1394", "xorg-libxcomposite", "libftdi", "ros-lyrical-octomap"]
   add_build: ["${{ cdt('libxcomposite-devel') if linux }}"]
+mola_launcher:
+  add_host: ["ros-lyrical-mrpt-libtclap"]
+  add_run: ["ros-lyrical-mrpt-libtclap"]
 mp2p_icp:
   add_host: ["ros-lyrical-mola-common", "ros-lyrical-mola-imu-preintegration", "ros-lyrical-mrpt-libbase", "ros-lyrical-mrpt-libgui", "ros-lyrical-mrpt-libtclap", "ros-lyrical-mrpt-libmaps", "ros-lyrical-mrpt-libobs", "ros-lyrical-mrpt-libposes", "tbb"]
   add_run: ["ros-lyrical-mola-common", "ros-lyrical-mola-imu-preintegration", "ros-lyrical-mrpt-libbase", "ros-lyrical-mrpt-libgui", "ros-lyrical-mrpt-libtclap", "ros-lyrical-mrpt-libmaps", "ros-lyrical-mrpt-libobs", "ros-lyrical-mrpt-libposes", "tbb"]

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -87,9 +87,36 @@ mola_launcher:
 mp2p_icp:
   add_host: ["ros-lyrical-mola-common", "ros-lyrical-mola-imu-preintegration", "ros-lyrical-mrpt-libbase", "ros-lyrical-mrpt-libgui", "ros-lyrical-mrpt-libtclap", "ros-lyrical-mrpt-libmaps", "ros-lyrical-mrpt-libobs", "ros-lyrical-mrpt-libposes", "tbb"]
   add_run: ["ros-lyrical-mola-common", "ros-lyrical-mola-imu-preintegration", "ros-lyrical-mrpt-libbase", "ros-lyrical-mrpt-libgui", "ros-lyrical-mrpt-libtclap", "ros-lyrical-mrpt-libmaps", "ros-lyrical-mrpt-libobs", "ros-lyrical-mrpt-libposes", "tbb"]
+# XSens support is disabled in these split MRPT builds. Avoid pulling libudev
+# (and a systemd build requiring a newer glibc than the ROS sysroot) into them.
+mrpt_libbase:
+  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  remove_host: ["libudev"]
+mrpt_libhwdrivers:
+  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  remove_host: ["libudev"]
+mrpt_libgui:
+  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  remove_host: ["libudev"]
 mrpt_libmaps:
-  add_host: ["octomap"]
+  add_host: ["octomap", "${{ 'libsystemd0 <258' if linux }}"]
   add_run: ["octomap"]
+  remove_host: ["libudev"]
+mrpt_libmath:
+  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  remove_host: ["libudev"]
+mrpt_libobs:
+  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  remove_host: ["libudev"]
+mrpt_libopengl:
+  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  remove_host: ["libudev"]
+mrpt_libposes:
+  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  remove_host: ["libudev"]
+mrpt_libslam:
+  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  remove_host: ["libudev"]
 ros1_rosbag_storage_vendor:
   add_host: ["ros-noetic-roscpp", "ros-noetic-roslz4", "ros-noetic-rostest"]
   add_run: ["ros-noetic-roscpp", "ros-noetic-roslz4"]

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -90,32 +90,32 @@ mp2p_icp:
 # XSens support is disabled in these split MRPT builds. Avoid pulling libudev
 # (and a systemd build requiring a newer glibc than the ROS sysroot) into them.
 mrpt_libbase:
-  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  add_host: ["${{ 'libsystemd0 <258' if linux }}", "${{ 'libudev1 <258' if linux }}"]
   remove_host: ["libudev"]
 mrpt_libhwdrivers:
-  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  add_host: ["${{ 'libsystemd0 <258' if linux }}", "${{ 'libudev1 <258' if linux }}"]
   remove_host: ["libudev"]
 mrpt_libgui:
-  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  add_host: ["${{ 'libsystemd0 <258' if linux }}", "${{ 'libudev1 <258' if linux }}"]
   remove_host: ["libudev"]
 mrpt_libmaps:
-  add_host: ["octomap", "${{ 'libsystemd0 <258' if linux }}"]
+  add_host: ["octomap", "${{ 'libsystemd0 <258' if linux }}", "${{ 'libudev1 <258' if linux }}"]
   add_run: ["octomap"]
   remove_host: ["libudev"]
 mrpt_libmath:
-  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  add_host: ["${{ 'libsystemd0 <258' if linux }}", "${{ 'libudev1 <258' if linux }}"]
   remove_host: ["libudev"]
 mrpt_libobs:
-  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  add_host: ["${{ 'libsystemd0 <258' if linux }}", "${{ 'libudev1 <258' if linux }}"]
   remove_host: ["libudev"]
 mrpt_libopengl:
-  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  add_host: ["${{ 'libsystemd0 <258' if linux }}", "${{ 'libudev1 <258' if linux }}"]
   remove_host: ["libudev"]
 mrpt_libposes:
-  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  add_host: ["${{ 'libsystemd0 <258' if linux }}", "${{ 'libudev1 <258' if linux }}"]
   remove_host: ["libudev"]
 mrpt_libslam:
-  add_host: ["${{ 'libsystemd0 <258' if linux }}"]
+  add_host: ["${{ 'libsystemd0 <258' if linux }}", "${{ 'libudev1 <258' if linux }}"]
   remove_host: ["libudev"]
 ros1_rosbag_storage_vendor:
   add_host: ["ros-noetic-roscpp", "ros-noetic-roslz4", "ros-noetic-rostest"]

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -81,6 +81,9 @@ mrpt2:
   add_host:  ["assimp", "octomap", "tinyxml2", "libboost-devel", "jsoncpp", "gtest", "libboost-python-devel", "libdc1394", "xorg-libxcomposite", "libftdi", "ros-lyrical-octomap"]
   add_run:   ["assimp", "octomap", "tinyxml2", "libboost-devel", "jsoncpp", "gtest", "libboost-python-devel", "libdc1394", "xorg-libxcomposite", "libftdi", "ros-lyrical-octomap"]
   add_build: ["${{ cdt('libxcomposite-devel') if linux }}"]
+mp2p_icp:
+  add_host: ["ros-lyrical-mola-common", "ros-lyrical-mola-imu-preintegration", "ros-lyrical-mrpt-libbase", "ros-lyrical-mrpt-libgui", "ros-lyrical-mrpt-libtclap", "ros-lyrical-mrpt-libmaps", "ros-lyrical-mrpt-libobs", "ros-lyrical-mrpt-libposes", "tbb"]
+  add_run: ["ros-lyrical-mola-common", "ros-lyrical-mola-imu-preintegration", "ros-lyrical-mrpt-libbase", "ros-lyrical-mrpt-libgui", "ros-lyrical-mrpt-libtclap", "ros-lyrical-mrpt-libmaps", "ros-lyrical-mrpt-libobs", "ros-lyrical-mrpt-libposes", "tbb"]
 ros1_rosbag_storage_vendor:
   add_host: ["ros-noetic-roscpp", "ros-noetic-roslz4", "ros-noetic-rostest"]
   add_run: ["ros-noetic-roscpp", "ros-noetic-roslz4"]

--- a/patch/ros-lyrical-mrpt-libgui.patch
+++ b/patch/ros-lyrical-mrpt-libgui.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1249e6e..1154834 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -50,6 +50,7 @@ ExternalProject_Add(
+     # Main settings:
+     -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
++    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
+     # Disabled stuff:
+     -DDISABLE_JSONCPP=ON
+     -DMRPT_INSTALL_EXAMPLES=OFF

--- a/patch/ros-lyrical-mrpt-libmath.patch
+++ b/patch/ros-lyrical-mrpt-libmath.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 40a5930..61a0f4d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -50,6 +50,7 @@ ExternalProject_Add(
+     # Main settings:
+     -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
++    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
+     # Disabled stuff:
+     -DDISABLE_JSONCPP=ON
+     -DMRPT_INSTALL_EXAMPLES=OFF

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -100,6 +100,8 @@ magic_enum:
     max_pin: 'x.x'
 moveit_ros_visualization:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
+mrpt_libgui:
+  additional_cmake_args: "-DCMAKE_CXX_FLAGS=-includecassert"
 mrpt_libmath:
   additional_cmake_args: "-DCMAKE_CXX_FLAGS=-I$PREFIX/include/suitesparse"
 octomap:

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -100,6 +100,8 @@ magic_enum:
     max_pin: 'x.x'
 moveit_ros_visualization:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
+mrpt_libmath:
+  additional_cmake_args: "-DCMAKE_CXX_FLAGS=-I$PREFIX/include/suitesparse"
 octomap:
   generate_dummy_package_with_run_deps:
     dep_name: octomap

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -196,6 +196,7 @@ packages_select_by_deps:
       - camera_ros  # Depends on libcamera that is only available on linux
       - livox_ros_driver2
       - mavros
+      - mola
       - py_binding_tools
       - swri_serial_util  # Serial communication only implemented for linux
       - v4l2_camera  # Depends on v4l that is only available on linux

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -197,6 +197,7 @@ packages_select_by_deps:
       - livox_ros_driver2
       - mavros
       - mola
+      - mrpt_libtclap
       - py_binding_tools
       - swri_serial_util  # Serial communication only implemented for linux
       - v4l2_camera  # Depends on v4l that is only available on linux


### PR DESCRIPTION
Adds the MOLA metapackage dependency closure as an initial Linux-only build, including its MRPT and MP2P ICP dependencies.