### PR TITLE
Expand released Autoware package coverage

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -60,7 +60,6 @@ packages_select_by_deps:
   - autoware_geography_utils
   - autoware_global_parameter_loader
   - autoware_internal_debug_msgs
-  - autoware_internal_localization_msgs
   - autoware_internal_metric_msgs
   - autoware_internal_msgs
   - autoware_internal_perception_msgs
@@ -211,6 +210,7 @@ packages_select_by_deps:
       - autoware_core_control  # depends on autoware_motion_utils
       - autoware_core_localization  # depends on autoware_ekf_localizer
       - autoware_ekf_localizer  # Windows error: error C2338: static_assert failed: 'First argument to logging macros must be an rclcpp::Logger'
+      - autoware_internal_localization_msgs  # Generated Python type support exceeds MSVC path handling
       - autoware_lanlet2_utils  # Windows errors: C3546 (no parameter packs to expand), C2678 (no operator '|' for transform_view)
       - autoware_motion_utils  # Windows error: error C2765: 'function': an explicit specialization of a function template cannot have any default arguments
       - autoware_osqp_interface

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -50,17 +50,29 @@ packages_select_by_deps:
   - ament_cmake_mypy
   - apriltag_detector
   - asio_cmake_module
+  - autoware_adapi_v1_msgs
+  - autoware_adapi_version_msgs
+  - autoware_auto_msgs
   - autoware_cmake
   - autoware_common_msgs
   - autoware_component_interface_specs
   - autoware_control_msgs
   - autoware_geography_utils
   - autoware_global_parameter_loader
+  - autoware_internal_debug_msgs
+  - autoware_internal_localization_msgs
+  - autoware_internal_metric_msgs
   - autoware_internal_msgs
+  - autoware_internal_perception_msgs
+  - autoware_internal_planning_msgs
   - autoware_interpolation
   - autoware_kalman_filter
+  - autoware_lanelet2_extension
+  - autoware_lanelet2_extension_python
+  - autoware_lint_common
   - autoware_localization_msgs
   - autoware_map_msgs
+  - autoware_msgs
   - autoware_node
   - autoware_object_recognition_utils
   - autoware_perception_msgs
@@ -70,6 +82,17 @@ packages_select_by_deps:
   - autoware_signal_processing
   - autoware_system_msgs
   - autoware_utils
+  - autoware_utils_debug
+  - autoware_utils_diagnostics
+  - autoware_utils_geometry
+  - autoware_utils_logging
+  - autoware_utils_math
+  - autoware_utils_pcl
+  - autoware_utils_rclcpp
+  - autoware_utils_system
+  - autoware_utils_tf
+  - autoware_utils_uuid
+  - autoware_utils_visualization
   - autoware_v2x_msgs
   - autoware_vehicle_info_utils
   - autoware_vehicle_msgs


### PR DESCRIPTION
Selects all additional Autoware packages represented in the current Lyrical snapshot, including AD API, internal messages, lanelet2 extensions, and split autoware_utils packages. Full Autoware Universe is not released through the Lyrical rosdistro.