### PR TITLE
Add RTAB-Map

### DIFF
--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -85,7 +85,7 @@ ros1_rosbag_storage_vendor:
 popf:
   add_host: ["perl"]
 rtabmap:
-  add_host: ["${{ 'libgl-devel' if linux }}", "${{ 'libopengl-devel' if linux }}", "ceres-solver", "libboost-devel", "libdc1394", "libusb", "vtk"]
+  add_host: ["${{ 'libgl-devel' if linux }}", "${{ 'libopengl-devel' if linux }}", "ceres-solver", "libboost-devel", "${{ 'libdc1394' if not win }}", "libusb", "vtk"]
 backward_ros:
   add_host: ["${{ 'binutils' if linux }}", "${{ 'elfutils' if linux }}", "ros-lyrical-ament-cmake-libraries"]
 nav2_smac_planner:

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -85,7 +85,7 @@ ros1_rosbag_storage_vendor:
 popf:
   add_host: ["perl"]
 rtabmap:
-  add_host: ["${{ 'libgl-devel' if linux }}", "${{ 'libopengl-devel' if linux }}", "ceres-solver", "libdc1394", "libusb", "vtk"]
+  add_host: ["${{ 'libgl-devel' if linux }}", "${{ 'libopengl-devel' if linux }}", "ceres-solver", "libboost-devel", "libdc1394", "libusb", "vtk"]
 backward_ros:
   add_host: ["${{ 'binutils' if linux }}", "${{ 'elfutils' if linux }}", "ros-lyrical-ament-cmake-libraries"]
 nav2_smac_planner:

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -73,8 +73,6 @@ tvm_vendor:
   add_host: ["libblas", "openblas", "libcblas"]
 libphidget22:
   add_host: ["libusb"]
-libg2o:
-  add_host: ["qt", "libglu", "freeglut"]
 fmilibrary_vendor:
   add_host: ["fmilib"]
 mrpt2:
@@ -88,8 +86,6 @@ popf:
   add_host: ["perl"]
 rtabmap:
   add_host: ["${{ 'libgl-devel' if linux }}", "${{ 'libopengl-devel' if linux }}", "ceres-solver", "libdc1394", "libusb", "vtk"]
-  remove_host: ["ros-lyrical-gtsam", "ros-lyrical-libg2o"]
-  remove_run: ["ros-lyrical-gtsam", "ros-lyrical-libg2o"]
 backward_ros:
   add_host: ["${{ 'binutils' if linux }}", "${{ 'elfutils' if linux }}", "ros-lyrical-ament-cmake-libraries"]
 nav2_smac_planner:

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -88,6 +88,8 @@ popf:
   add_host: ["perl"]
 rtabmap:
   add_host: ["${{ 'libgl-devel' if linux }}", "${{ 'libopengl-devel' if linux }}", "ceres-solver", "libdc1394", "libusb", "vtk"]
+  remove_host: ["ros-lyrical-libg2o"]
+  remove_run: ["ros-lyrical-libg2o"]
 backward_ros:
   add_host: ["${{ 'binutils' if linux }}", "${{ 'elfutils' if linux }}", "ros-lyrical-ament-cmake-libraries"]
 nav2_smac_planner:

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -88,8 +88,8 @@ popf:
   add_host: ["perl"]
 rtabmap:
   add_host: ["${{ 'libgl-devel' if linux }}", "${{ 'libopengl-devel' if linux }}", "ceres-solver", "libdc1394", "libusb", "vtk"]
-  remove_host: ["ros-lyrical-libg2o"]
-  remove_run: ["ros-lyrical-libg2o"]
+  remove_host: ["ros-lyrical-gtsam", "ros-lyrical-libg2o"]
+  remove_run: ["ros-lyrical-gtsam", "ros-lyrical-libg2o"]
 backward_ros:
   add_host: ["${{ 'binutils' if linux }}", "${{ 'elfutils' if linux }}", "ros-lyrical-ament-cmake-libraries"]
 nav2_smac_planner:

--- a/patch/ros-lyrical-rtabmap.patch
+++ b/patch/ros-lyrical-rtabmap.patch
@@ -16,3 +16,13 @@ index b7d36de..44e1164 100644
  ENDIF(WITH_GTSAM)
  
  IF(WITH_MRPT)
+@@ -578,7 +582,7 @@ ENDIF(WITH_POINTMATCHER)
+ IF(libpointmatcher_FOUND OR GTSAM_FOUND)
+-    find_package(Boost COMPONENTS thread filesystem system program_options date_time REQUIRED)
++    find_package(Boost COMPONENTS thread filesystem program_options date_time REQUIRED)
+     IF(Boost_MINOR_VERSION GREATER 47)
+-        find_package(Boost COMPONENTS thread filesystem system program_options date_time chrono timer serialization REQUIRED)
++        find_package(Boost COMPONENTS thread filesystem program_options date_time chrono timer serialization REQUIRED)
+     ENDIF(Boost_MINOR_VERSION GREATER 47)
+     IF(WIN32)
+         MESSAGE(STATUS "Boost_LIBRARY_DIRS=${Boost_LIBRARY_DIRS}")

--- a/patch/ros-lyrical-rtabmap.patch
+++ b/patch/ros-lyrical-rtabmap.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b7d36de..44e1164 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -530,8 +530,12 @@ IF(WITH_G2O)
+ ENDIF(WITH_G2O)
+ 
+ IF(WITH_GTSAM)
+-    # Force config mode to ignore PCL's findGTSAM.cmake file
++    # GTSAM's config searches for Eigen. Prefer Eigen's config so RTAB-Map's
++    # legacy FindEigen3 module does not try to parse Eigen 5 headers.
++    SET(_RTABMAP_CMAKE_FIND_PACKAGE_PREFER_CONFIG ${CMAKE_FIND_PACKAGE_PREFER_CONFIG})
++    SET(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+     FIND_PACKAGE(GTSAM CONFIG QUIET)
++    SET(CMAKE_FIND_PACKAGE_PREFER_CONFIG ${_RTABMAP_CMAKE_FIND_PACKAGE_PREFER_CONFIG})
+ ENDIF(WITH_GTSAM)
+ 
+ IF(WITH_MRPT)

--- a/patch/ros-lyrical-rtabmap.patch
+++ b/patch/ros-lyrical-rtabmap.patch
@@ -26,6 +26,16 @@ index b7d36de..44e1164 100644
      ENDIF(Boost_MINOR_VERSION GREATER 47)
      IF(WIN32)
          MESSAGE(STATUS "Boost_LIBRARY_DIRS=${Boost_LIBRARY_DIRS}")
+@@ -112,5 +116,8 @@ if(MSVC)
+     endif()
+   endif()
+   add_compile_options("/bigobj")
++  # CoInitialize() is used by Windows GUI entry points without including the
++  # COM declaration header explicitly.
++  add_compile_options("/FIobjbase.h")
+ endif()
+ 
+ # Detect CPU arch and whether we are in 32 or 64 bit
 diff --git a/corelib/src/CMakeLists.txt b/corelib/src/CMakeLists.txt
 index b758ad0..3f29cba 100644
 --- a/corelib/src/CMakeLists.txt

--- a/patch/ros-lyrical-rtabmap.patch
+++ b/patch/ros-lyrical-rtabmap.patch
@@ -26,3 +26,14 @@ index b7d36de..44e1164 100644
      ENDIF(Boost_MINOR_VERSION GREATER 47)
      IF(WIN32)
          MESSAGE(STATUS "Boost_LIBRARY_DIRS=${Boost_LIBRARY_DIRS}")
+diff --git a/corelib/src/CMakeLists.txt b/corelib/src/CMakeLists.txt
+index b758ad0..3f29cba 100644
+--- a/corelib/src/CMakeLists.txt
++++ b/corelib/src/CMakeLists.txt
+@@ -855,0 +856,6 @@ ADD_LIBRARY(rtabmap::core ALIAS rtabmap_core)
++# GTSAM and this target both instantiate an identical inline TBB allocator
++# vector accessor on MSVC. Let the linker coalesce that duplicate definition.
++IF(MSVC)
++  TARGET_LINK_OPTIONS(rtabmap_core PRIVATE "/FORCE:MULTIPLE")
++ENDIF(MSVC)
++

--- a/patch/ros-lyrical-rtabmap.patch
+++ b/patch/ros-lyrical-rtabmap.patch
@@ -26,12 +26,13 @@ index b7d36de..44e1164 100644
      ENDIF(Boost_MINOR_VERSION GREATER 47)
      IF(WIN32)
          MESSAGE(STATUS "Boost_LIBRARY_DIRS=${Boost_LIBRARY_DIRS}")
-@@ -112,5 +116,8 @@ if(MSVC)
+@@ -112,5 +116,9 @@ if(MSVC)
      endif()
    endif()
    add_compile_options("/bigobj")
-+  # CoInitialize() is used by Windows GUI entry points without including the
-+  # COM declaration header explicitly.
++  # GUI entry points use CoInitialize(). Force the COM declarations while
++  # ensuring the modern Winsock header precedes windows.h in every source.
++  add_compile_options("/FIwinsock2.h")
 +  add_compile_options("/FIobjbase.h")
  endif()
  

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -134,7 +134,7 @@ pybind11_vendor:
 robot_state_publisher:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
 libg2o:
-  additional_cmake_args: "-DG2O_BUILD_APPS=OFF -DG2O_BUILD_EXAMPLES=OFF -DG2O_USE_OPENGL=OFF"
+  additional_cmake_args: "-DG2O_BUILD_APPS=OFF -DG2O_BUILD_EXAMPLES=OFF -DG2O_USE_OPENGL=OFF -DBUILD_LGPL_SHARED_LIBS=ON"
 rosx_introspection:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
 rviz_ogre_vendor:

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -133,6 +133,8 @@ pybind11_vendor:
   additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR"
 robot_state_publisher:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
+rtabmap:
+  additional_cmake_args: "-DWITH_G2O=OFF"
 rosx_introspection:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
 rviz_ogre_vendor:

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -134,7 +134,7 @@ pybind11_vendor:
 robot_state_publisher:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
 rtabmap:
-  additional_cmake_args: "-DWITH_G2O=OFF"
+  additional_cmake_args: "-DWITH_G2O=OFF -DWITH_GTSAM=OFF"
 rosx_introspection:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
 rviz_ogre_vendor:

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -133,8 +133,8 @@ pybind11_vendor:
   additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR"
 robot_state_publisher:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
-rtabmap:
-  additional_cmake_args: "-DWITH_G2O=OFF -DWITH_GTSAM=OFF"
+libg2o:
+  additional_cmake_args: "-DG2O_BUILD_APPS=OFF -DG2O_BUILD_EXAMPLES=OFF -DG2O_USE_OPENGL=OFF"
 rosx_introspection:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
 rviz_ogre_vendor:

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -126,6 +126,7 @@ packages_select_by_deps:
   - rmw_zenoh_cpp  # requested in https://github.com/RoboStack/ros-humble/issues/252
   - robot
   - robot-localization
+  - rtabmap
   - ros2_control
   - ros2_controllers
   - ros2_fmt_logger
@@ -174,7 +175,6 @@ packages_select_by_deps:
       - camera_ros  # Depends on libcamera that is only available on linux
       - livox_ros_driver2
       - py_binding_tools
-      - rtabmap
       - swri_serial_util  # Serial communication only implemented for linux
       - v4l2_camera  # Depends on v4l that is only available on linux
 

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -174,6 +174,7 @@ packages_select_by_deps:
       - camera_ros  # Depends on libcamera that is only available on linux
       - livox_ros_driver2
       - py_binding_tools
+      - rtabmap
       - swri_serial_util  # Serial communication only implemented for linux
       - v4l2_camera  # Depends on v4l that is only available on linux
 


### PR DESCRIPTION
Adds the released RTAB-Map package as an initial Linux-only build. The current repository snapshot contains the monolithic 0.22.1 release.