### PR TITLE
fix: ros2 cli autocompletions

### DIFF
--- a/patch/ros-lyrical-ros2cli.patch
+++ b/patch/ros-lyrical-ros2cli.patch
@@ -1,0 +1,34 @@
+diff --git a/ros2cli/completion/ros2-argcomplete.zsh b/ros2cli/completion/ros2-argcomplete.zsh
+index b9fc309..14279de 100644
+--- a/ros2cli/completion/ros2-argcomplete.zsh
++++ b/ros2cli/completion/ros2-argcomplete.zsh
+@@ -20,6 +20,6 @@ autoload -U +X bashcompinit && bashcompinit
+ # Get this scripts directory
+ __ros2cli_completion_dir=${0:a:h}
+ # Just source the bash version, it works in zsh too
+-source "$__ros2cli_completion_dir/ros2-argcomplete.bash"
++source "$CONDA_PREFIX/share/bash-completion/completions/ros2-argcomplete.bash"
+ # Cleanup
+ unset __ros2cli_completion_dir
+diff --git a/ros2cli/setup.py b/ros2cli/setup.py
+index ef1ec86..9ceafb2 100644
+--- a/ros2cli/setup.py
++++ b/ros2cli/setup.py
+@@ -24,6 +24,17 @@ setup(
+             'completion/ros2-argcomplete.fish',
+             'completion/ros2-argcomplete.zsh',
+         ]),
++
++        # [pixi] install autocompletion scripts
++        ('share/bash-completion/completions', [
++            'completion/ros2-argcomplete.bash',
++        ]),
++        ('share/zsh/site-functions', [
++            'completion/ros2-argcomplete.zsh',
++        ]),
++        ('share/fish/vendor_completions.d', [
++            'completion/ros2-argcomplete.fish',
++        ]),
+     ],
+     package_data={'': ['py.typed']},
+     zip_safe=False,

--- a/patch/ros-lyrical-rosidl.patch
+++ b/patch/ros-lyrical-rosidl.patch
@@ -1,0 +1,31 @@
+diff --git a/rosidl_cli/completion/rosidl-argcomplete.zsh b/rosidl_cli/completion/rosidl-argcomplete.zsh
+index 9a86dbd..a33f8e1 100644
+--- a/rosidl_cli/completion/rosidl-argcomplete.zsh
++++ b/rosidl_cli/completion/rosidl-argcomplete.zsh
+@@ -18,6 +18,6 @@ autoload -U +X bashcompinit && bashcompinit
+ # Get this scripts directory
+ __rosidl_cli_completion_dir=${0:a:h}
+ # Just source the bash version, it works in zsh too
+-source "$__rosidl_cli_completion_dir/rosidl-argcomplete.bash"
++source "$CONDA_PREFIX/share/bash-completion/completions/rosidl-argcomplete.bash"
+ # Cleanup
+ unset __rosidl_cli_completion_dir
+diff --git a/rosidl_cli/setup.py b/rosidl_cli/setup.py
+index 6b48abf..950d23a 100644
+--- a/rosidl_cli/setup.py
++++ b/rosidl_cli/setup.py
+@@ -23,6 +23,14 @@ setup(
+             'completion/rosidl-argcomplete.bash',
+             'completion/rosidl-argcomplete.zsh'
+         ]),
++
++        # [pixi] install autocompletion scripts
++        ('share/bash-completion/completions', [
++            'completion/rosidl-argcomplete.bash',
++        ]),
++        ('share/zsh/site-functions', [
++            'completion/rosidl-argcomplete.zsh'
++        ]),
+     ],
+     package_data={'': ['py.typed']},
+     zip_safe=False,

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -88,6 +88,8 @@ libcamera:
     override_version: '0.5.2'
 libcurl_vendor:
   additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR_IGNORE_SATISFIED_CHECK"
+libg2o:
+  additional_cmake_args: "-DG2O_BUILD_APPS=OFF -DG2O_BUILD_EXAMPLES=OFF -DG2O_USE_OPENGL=OFF -DBUILD_LGPL_SHARED_LIBS=ON"
 liblz4_vendor:
   additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR_IGNORE_SATISFIED_CHECK"
 librealsense2:
@@ -133,8 +135,10 @@ pybind11_vendor:
   additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR"
 robot_state_publisher:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
-libg2o:
-  additional_cmake_args: "-DG2O_BUILD_APPS=OFF -DG2O_BUILD_EXAMPLES=OFF -DG2O_USE_OPENGL=OFF -DBUILD_LGPL_SHARED_LIBS=ON"
+ros2cli:
+  build_number: 23
+rosidl_cli:
+  build_number: 23
 rosx_introspection:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
 rviz_ogre_vendor:
@@ -175,7 +179,3 @@ visp:
 zenoh_cpp_vendor:
   additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR_IGNORE_SATISFIED_CHECK -DUSE_SYSTEM_ZENOH=ON"
 # Remove all lines after this one on new full rebuild
-rosidl_cli:
-  build_number: 23
-ros2cli:
-  build_number: 23

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -175,3 +175,7 @@ visp:
 zenoh_cpp_vendor:
   additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR_IGNORE_SATISFIED_CHECK -DUSE_SYSTEM_ZENOH=ON"
 # Remove all lines after this one on new full rebuild
+rosidl_cli:
+  build_number: 23
+ros2cli:
+  build_number: 23

--- a/tests/ros-lyrical-ros2cli.yaml
+++ b/tests/ros-lyrical-ros2cli.yaml
@@ -1,0 +1,8 @@
+tests:
+  # Regression test for https://github.com/RoboStack/ros-humble/issues/271
+  - script:
+    - if: unix
+      then:
+        - test -f ${PREFIX}/share/bash-completion/completions/ros2-argcomplete.bash
+        - test -f ${PREFIX}/share/zsh/site-functions/ros2-argcomplete.zsh
+        - test -f ${PREFIX}/share/fish/vendor_completions.d/ros2-argcomplete.fish

--- a/tests/ros-lyrical-rosidl.yaml
+++ b/tests/ros-lyrical-rosidl.yaml
@@ -1,0 +1,7 @@
+tests:
+  # Regression test for https://github.com/RoboStack/ros-humble/issues/271
+  - script:
+    - if: unix
+      then:
+        - test -f ${PREFIX}/share/bash-completion/completions/rosidl-argcomplete.bash
+        - test -f ${PREFIX}/share/zsh/site-functions/rosidl-argcomplete.zsh

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Reminder for next full rebuild, the next build number should be 23
+# Reminder for next full rebuild, the next build number should be 24
 build_number: 22
 
 mutex_package:

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -148,7 +148,6 @@ packages_select_by_deps:
   - rmw_zenoh_cpp  # requested in https://github.com/RoboStack/ros-humble/issues/252
   - robot
   - robot-localization
-  - rtabmap
   - ros2_control
   - ros2_controllers
   - ros2_fmt_logger
@@ -164,6 +163,7 @@ packages_select_by_deps:
   - rosidl_buffer_py
   - rqt_robot_monitor
   - rqt_runtime_monitor
+  - rtabmap
   - rviz_visual_tools
   - sbg_driver
   - simulation


### PR DESCRIPTION
Allows a user to run `ros2 <TABTAB>` and get the proper results. This does add a few miliseconds (100ms) of activation to the pixi shell.

- Patches the zsh script to link to the location of the bash script through the CONDA_PREFIX instead of assuming local install.