### PR TITLE
Add rosidl generator Python linkage regression test

### DIFF
--- a/tests/ros-lyrical-unique-identifier-msgs.yaml
+++ b/tests/ros-lyrical-unique-identifier-msgs.yaml
@@ -1,0 +1,6 @@
+tests:
+  # Regression test for https://github.com/RoboStack/ros-kilted/issues/76
+  - script:
+    - if: linux
+      then:
+        - resolved_symbols="$(ldd -r ${PREFIX}/lib/libunique_identifier_msgs__rosidl_generator_py.so 2>&1)"; printf '%s\n' "${resolved_symbols}"; ! printf '%s\n' "${resolved_symbols}" | grep -q 'undefined symbol'


### PR DESCRIPTION
## Summary

- add a Linux-only package test for generated rosidl Python support libraries
- verify that `libunique_identifier_msgs__rosidl_generator_py.so` has no unresolved symbols
- reuse the built package without maintaining a downstream ROS fixture

Regression test for RoboStack/ros-kilted#76.

## Validation

- parsed the test YAML with PyYAML
- confirmed the check reports the unresolved Python C API symbols with the currently published Lyrical build
- `git diff --cached --check` passed before commit

The package test will execute when `ros-lyrical-unique-identifier-msgs` is next rebuilt; the currently published build may be skipped by Vinca's existing-package logic.